### PR TITLE
Allow options file to be specified on the command line

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "devDependencies": {
     "babel-cli": "^6.5.1",
     "babel-eslint": "^4.1.8",
-    "babel-plugin-rewire": "^1.0.0-beta-5",
     "babel-plugin-transform-class-properties": "^6.5.2",
     "babel-preset-es2015": "^6.5.0",
     "babel-register": "^6.5.2",

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -8,7 +8,7 @@ import { existsFileSync } from '../util/exists';
 import parseConfig from './parseConfig';
 
 const cliOptions = parseArgv(process.argv.slice(2), true);
-const configOptions = parseConfig();
+const configOptions = parseConfig(cliOptions.opts);
 const defaultOptions = parseArgv([]);
 
 const options = _.defaults({}, cliOptions, configOptions, defaultOptions);

--- a/src/cli/parseArgv.js
+++ b/src/cli/parseArgv.js
@@ -162,7 +162,6 @@ const options = {
     describe: 'path to webpack-mocha options file',
     group: BASIC_GROUP,
     requiresArg: true,
-    default: 'mocha-webpack.opts',
   },
 };
 

--- a/src/cli/parseArgv.js
+++ b/src/cli/parseArgv.js
@@ -157,6 +157,13 @@ const options = {
     group: BASIC_GROUP,
     requiresArg: true,
   },
+  opts: {
+    type: 'string',
+    describe: 'path to webpack-mocha options file',
+    group: BASIC_GROUP,
+    requiresArg: true,
+    default: 'mocha-webpack.opts',
+  },
 };
 
 const paramList = (opts) => _.map(_.keys(opts), _.camelCase);

--- a/src/cli/parseConfig.js
+++ b/src/cli/parseConfig.js
@@ -5,16 +5,18 @@ import parseArgv from './parseArgv';
 const defaultConfig = 'mocha-webpack.opts';
 
 function handleMissingConfig(config) {
-  if (config === defaultConfig) {
-    return {};
+  if (config) {
+    throw new Error(`Options file '${config}' not found`);
   }
 
-  throw new Error(`Options file '${config}' not found`);
+  return {};
 }
 
-export default function parseConfig(config = defaultConfig) {
+export default function parseConfig(explicitConfig) {
+  const config = explicitConfig || defaultConfig;
+
   if (!existsFileSync(config)) {
-    return handleMissingConfig(config);
+    return handleMissingConfig(explicitConfig);
   }
 
   const argv = fs.readFileSync(config, 'utf8')

--- a/src/cli/parseConfig.js
+++ b/src/cli/parseConfig.js
@@ -2,15 +2,26 @@ import fs from 'fs';
 import { existsFileSync } from '../util/exists';
 import parseArgv from './parseArgv';
 
-export default function parseConfig(config) {
-  if (existsFileSync(config)) {
-    const argv = fs.readFileSync(config, 'utf8')
-      .replace(/\\\s/g, '%20')
-      .split(/\s/)
-      .filter(Boolean)
-      .map((value) => value.replace(/%20/g, ' '));
-    const defaultOptions = parseArgv(argv, true);
-    return defaultOptions;
+const defaultConfig = 'mocha-webpack.opts';
+
+function handleMissingConfig(config) {
+  if (config === defaultConfig) {
+    return {};
   }
-  return {};
+
+  throw new Error(`Options file '${config}' not found`);
+}
+
+export default function parseConfig(config = defaultConfig) {
+  if (!existsFileSync(config)) {
+    return handleMissingConfig(config);
+  }
+
+  const argv = fs.readFileSync(config, 'utf8')
+    .replace(/\\\s/g, '%20')
+    .split(/\s/)
+    .filter(Boolean)
+    .map((value) => value.replace(/%20/g, ' '));
+  const defaultOptions = parseArgv(argv, true);
+  return defaultOptions;
 }

--- a/src/cli/parseConfig.js
+++ b/src/cli/parseConfig.js
@@ -2,9 +2,7 @@ import fs from 'fs';
 import { existsFileSync } from '../util/exists';
 import parseArgv from './parseArgv';
 
-const config = 'mocha-webpack.opts';
-
-export default function parseConfig() {
+export default function parseConfig(config) {
   if (existsFileSync(config)) {
     const argv = fs.readFileSync(config, 'utf8')
       .replace(/\\\s/g, '%20')

--- a/test/cli/parseArgv.test.js
+++ b/test/cli/parseArgv.test.js
@@ -767,7 +767,7 @@ describe('parseArgv', function () {
     });
 
     context('opts', function () {
-      it('uses mocha-webpack.opts as default value', function () {
+      it('has no default value', function () {
         // given
         const argv = this.argv;
 
@@ -775,7 +775,7 @@ describe('parseArgv', function () {
         const parsedArgv = this.parseArgv(argv);
 
         // then
-        assert.propertyVal(parsedArgv, 'opts', 'mocha-webpack.opts');
+        assert.notProperty(parsedArgv, 'opts');
       });
 
 

--- a/test/cli/parseArgv.test.js
+++ b/test/cli/parseArgv.test.js
@@ -765,5 +765,36 @@ describe('parseArgv', function () {
         });
       }
     });
+
+    context('opts', function () {
+      it('uses mocha-webpack.opts as default value', function () {
+        // given
+        const argv = this.argv;
+
+        // when
+        const parsedArgv = this.parseArgv(argv);
+
+        // then
+        assert.propertyVal(parsedArgv, 'opts', 'mocha-webpack.opts');
+      });
+
+
+      const parameters = [
+        { given: ['--opts', 'path/to/other.opts'], expected: 'path/to/other.opts' },
+      ];
+
+      for (const parameter of parameters) {
+        it(`parses ${parameter.given.join(' ')}`, function () { // eslint-disable-line no-loop-func
+          // given
+          const argv = this.argv.concat(parameter.given);
+
+          // when
+          const parsedArgv = this.parseArgv(argv);
+
+          // then
+          assert.propertyVal(parsedArgv, 'opts', parameter.expected);
+        });
+      }
+    });
   });
 });

--- a/test/cli/parseConfig.test.js
+++ b/test/cli/parseConfig.test.js
@@ -12,6 +12,15 @@ describe('parseConfig', function () {
     assert.deepEqual(parseConfig(), {});
   });
 
+  it('throws an error when explicitly-specified default config file is missing', function () {
+    const fn = () => {
+      parseConfig('mocha-webpack.opts');
+    };
+
+    // then
+    assert.throws(fn, /Options file 'mocha-webpack.opts' not found/);
+  });
+
   it('throws an error when specified config file is missing', function () {
     const fn = () => {
       parseConfig('missing-config.opts');

--- a/test/cli/parseConfig.test.js
+++ b/test/cli/parseConfig.test.js
@@ -1,41 +1,21 @@
 /* eslint-env node, mocha */
 /* eslint-disable func-names, prefer-arrow-callback, no-loop-func, max-len */
 
-import fs from 'fs';
 import path from 'path';
 import { assert } from 'chai';
-import { stub } from 'sinon';
 import parseConfig from '../../src/cli/parseConfig';
 
-const configFileName = 'mocha-webpack.opts';
+const configFileName = path.join(__dirname, 'fixture', 'config', 'mocha-webpack.opts');
 
 describe('parseConfig', function () {
   it('returns empty object when not exists', function () {
-    assert.doesNotThrow(parseConfig);
-    assert.deepEqual(parseConfig(), {});
+    assert.deepEqual(parseConfig('missing-config-file.opts'), {});
   });
 
   it(`parses ${configFileName} when exists and returns options`, function () {
-    const existsFileSyncMock = stub().returns(true);
-    const givenRc = fs.readFileSync(path.join(__dirname, 'fixture', 'config', configFileName), 'utf8');
     const expectedResult = require(path.join(__dirname, 'fixture', 'config', 'expected.json'));
-    const readFileSyncMock = stub().returns(givenRc);
-
-    parseConfig.__Rewire__('existsFileSync', existsFileSyncMock);
-    parseConfig.__Rewire__('fs', {
-      readFileSync: readFileSyncMock,
-    });
-
-    assert.doesNotThrow(parseConfig);
-
-    assert.isOk(existsFileSyncMock.calledWithExactly(configFileName));
-    assert.isOk(readFileSyncMock.calledWithExactly(configFileName, 'utf8'));
-
-    const parsedOptions = parseConfig();
+    const parsedOptions = parseConfig(configFileName);
 
     assert.deepEqual(parsedOptions, expectedResult);
-
-    parseConfig.__ResetDependency__('existsFileSync');
-    parseConfig.__ResetDependency__('fs');
   });
 });

--- a/test/cli/parseConfig.test.js
+++ b/test/cli/parseConfig.test.js
@@ -8,8 +8,17 @@ import parseConfig from '../../src/cli/parseConfig';
 const configFileName = path.join(__dirname, 'fixture', 'config', 'mocha-webpack.opts');
 
 describe('parseConfig', function () {
-  it('returns empty object when not exists', function () {
-    assert.deepEqual(parseConfig('missing-config-file.opts'), {});
+  it('returns empty object when default config file is missing', function () {
+    assert.deepEqual(parseConfig(), {});
+  });
+
+  it('throws an error when specified config file is missing', function () {
+    const fn = () => {
+      parseConfig('missing-config.opts');
+    };
+
+    // then
+    assert.throws(fn, /Options file 'missing-config.opts' not found/);
   });
 
   it(`parses ${configFileName} when exists and returns options`, function () {

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,5 +1,3 @@
 /* eslint-disable */
 
-require("babel-register")({
-  plugins: ["rewire"]
-});
+require("babel-register");


### PR DESCRIPTION
Add a `—opts` argument to the CLI to allow the `mocha-webpack.opts` to live somewhere else.

`--opts` matches the name of the argument that Mocha uses for the same purpose.  Using the same argument name makes it easier to convert an existing project from mocha to mocha-webpack.

With this flag, I was able to simplify the `parseConfig` tests to the point that `babel-plugin-rewire` is no longer needed, so the second commit removes it from the project.