### PR TITLE
fix cli arguments with multiple values

### DIFF
--- a/test/bin/include.test.js
+++ b/test/bin/include.test.js
@@ -16,12 +16,17 @@ const helper1 = `${path.join(helperDir, 'test-helper.js')}`;
 const helper2 = `${path.join(helperDir, 'test-helper-2.js')}`;
 
 
-function testInclude(entry, include, cb) {
-  exec(`node ${binPath} \"${entry}\" --include ${include}`, cb);
+function test(entry, options, cb) {
+  exec(`node ${binPath} \"${entry}\" ${options.join(' ')}  `, cb);
+}
+
+function testInclude(entry, includes, cb) {
+  const options = includes.map((value) => `--include ${value}`);
+  test(entry, options, cb);
 }
 
 function testSingleInclude(entry, done) {
-  return testInclude(entry, helper1, (err, stdout) => {
+  return testInclude(entry, [helper1], (err, stdout) => {
     assert.isNull(err);
     assert.include(stdout, 'first --include works');
     done();
@@ -29,7 +34,7 @@ function testSingleInclude(entry, done) {
 }
 
 function testMultiInclude(entry, done) {
-  return testInclude(entry, `${helper1} ${helper2}`, (err, stdout) => {
+  return testInclude(entry, [helper1, helper2], (err, stdout) => {
     assert.isNull(err);
     assert.include(stdout, 'first --include works');
     assert.include(stdout, 'second --include works');
@@ -86,7 +91,7 @@ describe('cli --include', function () {
     });
 
     it('include node_module', function (done) {
-      testInclude(path.join(testDir, 'test.js'), 'chai', (err) => {
+      testInclude(path.join(testDir, 'test.js'), ['chai'], (err) => {
         assert.isNull(err);
         done();
       });

--- a/test/cli/parseArgv.test.js
+++ b/test/cli/parseArgv.test.js
@@ -27,7 +27,7 @@ describe('parseArgv', function () {
 
     it('should not throw for arrays', function () {
       // given
-      const argv = ['--require', 'test', 'test2'];
+      const argv = ['--require', 'test', '--require', 'test2'];
 
       // when
       const fn = () => {
@@ -423,7 +423,7 @@ describe('parseArgv', function () {
 
       const parameters = [
         { given: ['--require', 'test'], expected: ['test'] },
-        { given: ['--require', 'test', 'test2'], expected: ['test', 'test2'] },
+        { given: ['--require', 'test', '--require', 'test2'], expected: ['test', 'test2'] },
         { given: ['--r', 'test'], expected: ['test'] },
         { given: ['-r', 'test'], expected: ['test'] },
       ];
@@ -459,7 +459,7 @@ describe('parseArgv', function () {
 
       const parameters = [
         { given: ['--include', 'test'], expected: ['test'] },
-        { given: ['--include', 'test', 'test2'], expected: ['test', 'test2'] },
+        { given: ['--include', 'test', '--include', 'test2'], expected: ['test', 'test2'] },
       ];
 
       for (const parameter of parameters) {


### PR DESCRIPTION
Cli arguments were parsed in a different way than mocha does it. It was possible to pass multiple arguments to some options without repeating the option. This leads to some unexpected behavior when the test entry was the last option (see #7).


For example the entry of the following command was interpreted as a part of the require option.
```
$ mocha-webpack --require source-map-support/register ./test/entry.js
```

To provide multiple values to some options it's necessary to repeat the option, like the following:
```
$ mocha-webpack  --require source-map-support/register  --require some-other-module ./test/entry.js
```