### PR TITLE
--version option doesn't work, gives error Cannot find module '../package'

### DIFF
--- a/src/cli/parseArgv.js
+++ b/src/cli/parseArgv.js
@@ -183,7 +183,7 @@ export default function parseArgv(argv, ignoreDefaults = false) {
   const parsedArgs = yargs(argv)
     .help('help')
     .alias('help', 'h', '?')
-    .version(() => require('../package').version)
+    .version(() => require('../../package.json').version)
     .demand(0, 1)
     .options(options)
     .strict()

--- a/test/bin/version.test.js
+++ b/test/bin/version.test.js
@@ -1,0 +1,22 @@
+/* eslint-env node, mocha */
+/* eslint-disable func-names, prefer-arrow-callback */
+
+import { assert } from 'chai';
+import path from 'path';
+import { exec } from 'child_process';
+
+const binPath = path.relative(process.cwd(), path.join('bin', '_mocha'));
+
+describe('cli - version', function () {
+  before(function () {
+    this.version = require('../../package.json').version;
+  });
+
+  it('--version prints the correct version', function (done) {
+    exec(`node ${binPath} --version`, (err, stdout) => {
+      assert.isNull(err);
+      assert.include(stdout, this.version);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Fix for `mocha-webpack --version`, see #11