### PR TITLE
Fix InjectChangedFilesPlugin to escape quotes in webpackManifest files

### DIFF
--- a/src/webpack/InjectChangedFilesPlugin.js
+++ b/src/webpack/InjectChangedFilesPlugin.js
@@ -86,7 +86,8 @@ export default class InjectChangedFilesPlugin {
 
      const result = new ReplaceSource(original);
      const regex = /__webpackManifest__\s*=\s*\[\s*\]/g;
-     const changedFiles = JSON.stringify(this.hotFiles.concat(this.failedFiles));
+     const files = this.hotFiles.concat(this.failedFiles);
+     const changedFiles = `['${files.join("', '")}']`;
      const replacement = `__webpackManifest__ = ${changedFiles}`;
 
      let match;


### PR DESCRIPTION
The `--watch` option is not working for me – it ends up failing with a syntax error when the code generated by `InjectChangedFilesPlugin` / webpack gets eval'd by `mocha-webpack`. You can verify this error in my sample app:

```sh
git clone git@github.com:thiagoa/sample-app
cd sample-app
npm install
node_modules/.bin/mocha-webpack # Works
node_modules/.bin/mocha-webpack --watch # Does not work
```

I get the following error:

> eval("\"use strict\";\n\n// This gets replaced by webpack with the updated files on rebuild\nvar __webpackManifest__ = ["./6bb2e8176d135c5dda2c2b116019dd85-entry.js","./smoke.spec.js","chai","./lib/chai","assertion-error","./chai/utils","./test","./flag","type-detect","./lib/type","./expectTypes","./getMessage","./getActual","./inspect","./getName","./getProperties","./getEnumerableProperties","./objDisplay","./chai/config","./transferFlags","deep-eql","./lib/eql","./getPathValue","./getPathInfo","./hasProperty","./addProperty","./addMethod","./overwriteProperty","./overwriteMethod","./addChainableMethod","./overwriteChainableMethod","./chai/assertion","./chai/core/assertions","./chai/interface/expect","./chai/interface/should","./chai/interface/assert"];\n\nvar testsCont

The fix here consists in escaping the double quotes, so that evaluation of the code succeeds.

I'll be happy to resolve any issues with this pull request, if there are any please let me know 😄 