### PR TITLE
Let mocha use its default "colors" setting when not specified

### DIFF
--- a/src/cli/parseArgv.js
+++ b/src/cli/parseArgv.js
@@ -15,6 +15,7 @@ const options = {
   colors: {
     alias: 'c',
     type: 'boolean',
+    default: undefined,
     describe: 'force enabling of colors',
     group: OUTPUT_GROUP,
   },

--- a/test/cli/parseArgv.test.js
+++ b/test/cli/parseArgv.test.js
@@ -139,7 +139,7 @@ describe('parseArgv', function () {
     });
 
     context('colors', function () {
-      it('uses false as default value', function () {
+      it('uses undefined as default value', function () {
         // given
         const argv = this.argv;
 
@@ -147,7 +147,7 @@ describe('parseArgv', function () {
         const parsedArgv = this.parseArgv(argv);
 
         // then
-        assert.propertyVal(parsedArgv, 'colors', false);
+        assert.notProperty(parsedArgv, 'colors');
       });
 
 
@@ -161,6 +161,20 @@ describe('parseArgv', function () {
 
           // then
           assert.propertyVal(parsedArgv, 'colors', true);
+        });
+      }
+
+
+      for (const parameter of['--no-colors', '--colors=false', '--no-c', '--c=false']) {
+        it(`parses ${parameter}`, function () { // eslint-disable-line no-loop-func
+          // given
+          const argv = this.argv.concat([parameter]);
+
+          // when
+          const parsedArgv = this.parseArgv(argv);
+
+          // then
+          assert.propertyVal(parsedArgv, 'colors', false);
         });
       }
     });


### PR DESCRIPTION
Mocha uses its defaults when the parameter to `.useColors` is `undefined`: https://github.com/mochajs/mocha/blob/master/lib/mocha.js#L344-L347

Right now, you are always overriding it to `false` unless an argument is given to always override it to `true`, which defeats the point of mocha's default.