### PR TITLE
Support webpack 2 beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "license": "MIT",
   "peerDependencies": {
     "mocha": "^2.4.5",
-    "webpack": "^1.12.13"
+    "webpack": "^1.12.13 || ^2.1.0-beta.15"
   },
   "devDependencies": {
     "babel-cli": "^6.5.1",

--- a/src/webpack/InjectChangedFilesPlugin.js
+++ b/src/webpack/InjectChangedFilesPlugin.js
@@ -68,7 +68,7 @@ export default class InjectChangedFilesPlugin {
 
           // and finally set changed files
           chunk.files.forEach((file) => {
-            if (!chunk.initial) {
+            if (!(chunk.isInitial ? chunk.isInitial() : chunk.initial)) {
               return;
             }
             this.setChangedFiles(compilation, file);


### PR DESCRIPTION
Updates the `peerDependencies` and updates the `InjectChangedFilesPlugin` for API change in `2.1.0-beta.16`.

All tests pass with `npm install webpack@^1.12.13`, `npm install webpack@2.1.0-beta.15` and `npm install webpack@2.1.0-beta.17`; it also can be successfully used on a large webpack2 codebase with a (tiny...) test suite. Did not test other versions.