### PR TITLE
ci tests for webpack v1 and v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,17 @@
 language: node_js
+
 node_js:
   - "0.12"
   - "4"
   - "5"
+
+env:
+  - WEBPACK_VERSION=1
+  - WEBPACK_VERSION=beta
+
+before_script:
+  - "npm install webpack@$WEBPACK_VERSION"
+
 script:
   - npm run lint
   - npm run test


### PR DESCRIPTION
With  #32 we added support for webpack 2. This PR adjusts the configuration of travis to test webpack@1 and webpack@2. 