### PR TITLE
custom file watcher configuration via watchOptions

### DIFF
--- a/src/webpack/watch.js
+++ b/src/webpack/watch.js
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import createCompiler from './createCompiler';
 
 export default function watch(webpackConfig, cb) {
+  const watchOptions = webpackConfig.watchOptions || {};
   const compiler = createCompiler(webpackConfig, cb);
-  compiler.watch({}, _.noop);
+  compiler.watch(watchOptions, _.noop);
 }


### PR DESCRIPTION
This PR addresses #30 and adds support for custom file watcher configuration via watchOptions (see [webpack configuration](https://webpack.github.io/docs/configuration.html#watchoptions-aggregatetimeout))