### PR TITLE
include source-map-support by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,11 +141,7 @@ $ mocha-webpack --growl --colors --webpack-config webpack.config-test.js "src/**
 ```
 ### Sourcemaps
 
-For using sourcemaps with mocha-webpack you just need to enable sourcemaps in your webpack config and use [source-map-support] to apply sourcemaps.
-
-```bash
-$ npm install --save-dev source-map-support
-```
+Sourcemap support is already applied for you via [source-map-support](https://github.com/evanw/node-source-map-support) by mocha-webpack. You just need to enable them in your webpack config via the `devtool` setting.
 
 **webpack.config-test.js**
 ```javascript
@@ -161,11 +157,6 @@ module.exports = {
   externals: [nodeExternals()], // in order to ignore all modules in node_modules folder
   devtool: "cheap-module-source-map" // faster than 'source-map'
 };
-```
-
-**mocha-webpack.opts**
-```
---require source-map-support/register
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "lodash": "^4.3.0",
     "nodent-runtime": "^3.0.3",
     "normalize-path": "^2.0.1",
+    "source-map-support": "^0.4.6",
     "webpack-info-plugin": "^0.1.0",
     "webpack-sources": "^0.1.1",
     "yargs": "^4.8.0"

--- a/src/webpack/compiler/createCompiler.js
+++ b/src/webpack/compiler/createCompiler.js
@@ -1,5 +1,6 @@
 // @flow
 import webpack from 'webpack';
+import registerSourcemapSupport from '../util/registerSourcemapSupport';
 import type { Compiler } from '../types';
 
 export default function createCompiler(webpackConfig: {}, cb: (err: ?{}) => void): Compiler {
@@ -44,5 +45,8 @@ export default function createCompiler(webpackConfig: {}, cb: (err: ?{}) => void
       cb();
     }
   });
+
+  registerSourcemapSupport(compiler);
+
   return compiler;
 }

--- a/src/webpack/util/registerSourcemapSupport.js
+++ b/src/webpack/util/registerSourcemapSupport.js
@@ -1,0 +1,9 @@
+import sourceMapSupport from 'source-map-support';
+
+export default function registerSourcemapSupport() {
+  sourceMapSupport.install({
+    emptyCacheBetweenOperations: true,
+    handleUncaughtExceptions: false,
+    environment: 'node',
+  });
+}


### PR DESCRIPTION
Including source-map-support by default is necessary before we can switch to an in-memory fs as suggested in #25.
