### PR TITLE
in-memory filesystem for webpack assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Seems pretty easy. But there are some disadvantages with this approach:
 
 This project is a optimized version of this simple approach with following features:
 - precompiles your test files automatically with webpack before executing tests
+- no files are written to disk
 - define tests to execute like mocha:
   - run a single test file
   - run all tests in the desired directory & if desired in all subdirectories
@@ -78,8 +79,6 @@ module.exports = {
 ```
 
 Maybe you noticed that [entry](https://webpack.github.io/docs/configuration.html#entry), [output.filename](https://webpack.github.io/docs/configuration.html#output-filename) and [output.path](https://webpack.github.io/docs/configuration.html#output-path) are completely missing in this config. mocha-webpack does this automatically for you and if you would specify it anyway, it will be overridden by mocha-webpack.
-
-**Note:** mocha-webpack emits the generated files currently into `./tmp/mocha-webpack`. So you should make sure that this folder is ignored in your `.gitignore` file. In future versions this could be unnecessary.
 
 If you want to use JavaScript preprocessor such as [Babel](https://babeljs.io/) or [CoffeeScript](http://coffeescript.org/)
 in your webpack config file then give it a name ending with corresponding extension:
@@ -143,6 +142,8 @@ $ mocha-webpack --growl --colors --webpack-config webpack.config-test.js "src/**
 
 Sourcemap support is already applied for you via [source-map-support](https://github.com/evanw/node-source-map-support) by mocha-webpack. You just need to enable them in your webpack config via the `devtool` setting.
 
+**Note**: For a proper debug experience in your IDE (setting breakpoints right into your code) you need to use a `devtool` which inlines the sourcemaps like `inline-source-map`.
+
 **webpack.config-test.js**
 ```javascript
 var nodeExternals = require('webpack-node-externals');
@@ -155,7 +156,7 @@ module.exports = {
   },
   target: 'node', // in order to ignore built-in modules like path, fs, etc.
   externals: [nodeExternals()], // in order to ignore all modules in node_modules folder
-  devtool: "cheap-module-source-map" // faster than 'source-map'
+  devtool: "inline-source-map"
 };
 ```
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ $ mocha-webpack --growl --colors --webpack-config webpack.config-test.js "src/**
 
 Sourcemap support is already applied for you via [source-map-support](https://github.com/evanw/node-source-map-support) by mocha-webpack. You just need to enable them in your webpack config via the `devtool` setting.
 
-**Note**: For a proper debug experience in your IDE (setting breakpoints right into your code) you need to use a `devtool` which inlines the sourcemaps like `inline-source-map`.
+**Note**: For a proper debug experience in your IDE (setting breakpoints right into your code) you need to use a `devtool` which inlines the sourcemaps like `inline-cheap-module-source-map`.
 
 **webpack.config-test.js**
 ```javascript
@@ -156,7 +156,7 @@ module.exports = {
   },
   target: 'node', // in order to ignore built-in modules like path, fs, etc.
   externals: [nodeExternals()], // in order to ignore all modules in node_modules folder
-  devtool: "inline-source-map"
+  devtool: "inline-cheap-module-source-map"
 };
 ```
 

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "is-glob": "^2.0.1",
     "loader-utils": "^0.2.13",
     "lodash": "^4.3.0",
+    "memory-fs": "^0.4.1",
     "nodent-runtime": "^3.0.3",
     "normalize-path": "^2.0.1",
     "source-map-support": "^0.4.6",

--- a/src/MochaWebpack.js
+++ b/src/MochaWebpack.js
@@ -21,7 +21,6 @@ export type MochaWebpackOptions = {
   delay: boolean,
 };
 
-const noop = () => void 0;
 
 export default class MochaWebpack {
 
@@ -346,11 +345,11 @@ export default class MochaWebpack {
    * Run tests
    *
    * @public
-   * @param {Function} cb callback invoked on ready
+   * @return {Promise<number>} a Promise that gets resolved with the number of failed tests or rejected with build error
    */
-  async run(cb: (failures: number) => void = noop): Promise<void> {
+  async run(): Promise<number> {
     const runner = new TestRunner(this.entries, this.includes, this.options);
-    await runner.run(cb);
+    return await runner.run();
   }
 
   /**

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -99,9 +99,10 @@ Promise
     if (options.watch) {
       return mochaWebpack.watch();
     }
-    return mochaWebpack.run((failures) => {
-      exit(options.exit, failures);
-    });
+    return mochaWebpack.run();
+  })
+  .then((failures) => {
+    exit(options.exit, failures);
   })
   .catch((e) => {
     console.error(e.stack); // eslint-disable-line

--- a/src/runner/TestRunner.js
+++ b/src/runner/TestRunner.js
@@ -3,7 +3,7 @@ import path from 'path';
 import WebpackInfoPlugin from 'webpack-info-plugin';
 
 import { glob } from '../util/glob';
-import createCompiler from '../webpack/compiler/createCompiler';
+import createInMemoryCompiler from '../webpack/compiler/createInMemoryCompiler';
 import InjectChangedModulesPlugin from '../webpack/plugin/InjectChangedModulesPlugin';
 import { EntryConfig, KEY as ENTRY_CONFIG_KEY } from '../webpack/loader/entryLoader';
 import type { MochaWebpackOptions } from '../MochaWebpack';
@@ -38,7 +38,7 @@ export default class TestRunner {
     const config = await this.createWebpackConfig();
     const mocha = configureMocha(this.options);
 
-    const compiler = createCompiler(config, (err) => {
+    const compiler = createInMemoryCompiler(config, (err) => {
       if (err) {
         cb(1);
         return;
@@ -84,7 +84,7 @@ export default class TestRunner {
       }
     };
 
-    const compiler = createCompiler(config, (err) => {
+    const compiler = createInMemoryCompiler(config, (err) => {
       if (err) {
         // wait for fixed tests
         return;

--- a/src/runner/TestRunner.js
+++ b/src/runner/TestRunner.js
@@ -110,6 +110,7 @@ export default class TestRunner {
 
     const watchOptions = config.watchOptions || {};
     compiler.watch(watchOptions, noop);
+    return new Promise(() => void 0); // never ending story
   }
 
   async createWebpackConfig(): {} {

--- a/src/runner/TestRunner.js
+++ b/src/runner/TestRunner.js
@@ -33,20 +33,31 @@ export default class TestRunner {
     this.outputFilePath = path.join(this.tmpPath, 'bundle.js');
   }
 
-  async run(cb: (failures: number) => void): void {
+  async run(): Promise<number> {
     const config = await this.createWebpackConfig();
     const mocha = configureMocha(this.options);
+    let compiler;
+    let failures = 0;
+    try {
+      failures = await new Promise((resolve, reject) => {
+        compiler = createInMemoryCompiler(config, (err) => {
+          if (err) {
+            reject(err);
+            return;
+          }
+          mocha.files = [this.outputFilePath];
+          mocha.run(resolve);
+        });
 
-    const compiler = createInMemoryCompiler(config, (err) => {
-      if (err) {
-        cb(1);
-        return;
+        compiler.run(noop);
+      });
+    } finally {
+      // clean up single run
+      if (typeof compiler !== 'undefined' && typeof compiler.mochaWebpackDispose === 'function') {
+        compiler.mochaWebpackDispose();
       }
-      mocha.files = [this.outputFilePath];
-      mocha.run(cb);
-    });
-
-    compiler.run(noop);
+    }
+    return failures;
   }
 
   async watch(): void {

--- a/src/runner/TestRunner.js
+++ b/src/runner/TestRunner.js
@@ -30,8 +30,7 @@ export default class TestRunner {
 
     this.options = options;
     this.tmpPath = path.join(this.options.cwd, '.tmp', 'mocha-webpack');
-    this.outputFilePath = path.join(this.tmpPath, `${Date.now()}-bundle.js`);
-    // this.outputFilePath = path.join(this.tmpPath, 'bundle.js');
+    this.outputFilePath = path.join(this.tmpPath, 'bundle.js');
   }
 
   async run(cb: (failures: number) => void): void {

--- a/src/util/registerRequireHook.js
+++ b/src/util/registerRequireHook.js
@@ -50,21 +50,21 @@ export default function registerRequireHook(dotExt: string, resolve: (path: stri
 
   const resolvePath = (path, parent) => {
     // get CommonJS module source code for this require() call
-    const source = resolve(path, parent);
+    const { path: resolvedPath, source } = resolve(path, parent);
 
     // if no CommonJS module source code returned - skip this require() hook
-    if (source === null) {
+    if (path === null) {
       return void 0;
     }
 
     // flush require() cache
-    delete require.cache[path];
+    delete require.cache[resolvedPath];
 
     // put the CommonJS module source code into the hash
-    sourceCache[path] = source;
+    sourceCache[resolvedPath] = source;
 
     // return the path to be require()d in order to get the CommonJS module source code
-    return path;
+    return resolvedPath;
   };
 
   const resolveSource = (path) => {

--- a/src/util/registerRequireHook.js
+++ b/src/util/registerRequireHook.js
@@ -70,7 +70,6 @@ export default function registerRequireHook(dotExt: string, resolve: (path: stri
   const resolveSource = (path) => {
     const source = sourceCache[path];
     delete sourceCache[path];
-    affectedFiles[path] = true;
     return source;
   };
 
@@ -88,6 +87,8 @@ export default function registerRequireHook(dotExt: string, resolve: (path: stri
       (originalLoader || Module._extensions['.js'])(module, filename);
       return;
     }
+
+    affectedFiles[filename] = true;
 
     // compile javascript module from its source
     module._compile(source, filename);

--- a/src/webpack/compiler/createCompiler.js
+++ b/src/webpack/compiler/createCompiler.js
@@ -1,6 +1,5 @@
 // @flow
 import webpack from 'webpack';
-import registerSourcemapSupport from '../util/registerSourcemapSupport';
 import type { Compiler } from '../types';
 
 export default function createCompiler(webpackConfig: {}, cb: (err: ?{}) => void): Compiler {
@@ -45,8 +44,6 @@ export default function createCompiler(webpackConfig: {}, cb: (err: ?{}) => void
       cb();
     }
   });
-
-  registerSourcemapSupport(compiler);
 
   return compiler;
 }

--- a/src/webpack/compiler/createInMemoryCompiler.js
+++ b/src/webpack/compiler/createInMemoryCompiler.js
@@ -5,6 +5,6 @@ import type { Compiler } from '../types';
 
 export default function createInMemoryCompiler(webpackConfig: {}, cb: (err: ?{}) => void): Compiler {
   const compiler: Compiler = createCompiler(webpackConfig, cb);
-  registerInMemoryCompiler(compiler);
+  compiler.mochaWebpackDispose = registerInMemoryCompiler(compiler);
   return compiler;
 }

--- a/src/webpack/compiler/createInMemoryCompiler.js
+++ b/src/webpack/compiler/createInMemoryCompiler.js
@@ -1,0 +1,10 @@
+// @flow
+import createCompiler from './createCompiler';
+import registerInMemoryCompiler from './registerInMemoryCompiler';
+import type { Compiler } from '../types';
+
+export default function createInMemoryCompiler(webpackConfig: {}, cb: (err: ?{}) => void): Compiler {
+  const compiler: Compiler = createCompiler(webpackConfig, cb);
+  registerInMemoryCompiler(compiler);
+  return compiler;
+}

--- a/src/webpack/compiler/registerInMemoryCompiler.js
+++ b/src/webpack/compiler/registerInMemoryCompiler.js
@@ -1,7 +1,7 @@
 import path from 'path';
 import sourceMapSupport from 'source-map-support';
 import MemoryFileSystem from 'memory-fs';
-import registerRequireHook from '../util/registerRequireHook';
+import registerRequireHook from '../../util/registerRequireHook';
 import type { Compiler } from '../types';
 
 const noop = () => null;

--- a/src/webpack/compiler/registerInMemoryCompiler.js
+++ b/src/webpack/compiler/registerInMemoryCompiler.js
@@ -1,0 +1,29 @@
+import sourceMapSupport from 'source-map-support';
+import MemoryFileSystem from 'memory-fs';
+import registerRequireHook from '../util/registerRequireHook';
+import type { Compiler } from '../types';
+
+export default function registerInMemoryCompiler(compiler: Compiler): void {
+  const memoryFs = new MemoryFileSystem();
+  compiler.outputFileSystem = memoryFs; // eslint-disable-line no-param-reassign
+
+  const readFile = (filePath) => {
+    try {
+      const code = memoryFs.readFileSync(filePath, 'utf8');
+      return code;
+    } catch (e) {
+      return null;
+    }
+  };
+
+  // install require hook to be able to require webpack bundles from memory
+  registerRequireHook('.js', readFile);
+
+  // install source map support to read source map from memory
+  sourceMapSupport.install({
+    emptyCacheBetweenOperations: true,
+    handleUncaughtExceptions: false,
+    environment: 'node',
+    retrieveFile: readFile,
+  });
+}

--- a/src/webpack/compiler/registerInMemoryCompiler.js
+++ b/src/webpack/compiler/registerInMemoryCompiler.js
@@ -4,11 +4,13 @@ import MemoryFileSystem from 'memory-fs';
 import registerRequireHook from '../util/registerRequireHook';
 import type { Compiler } from '../types';
 
+const noop = () => null;
+
 export default function registerInMemoryCompiler(compiler: Compiler): void {
   const memoryFs = new MemoryFileSystem();
   compiler.outputFileSystem = memoryFs; // eslint-disable-line no-param-reassign
 
-  const readFile = (filePath) => {
+  let readFile = (filePath) => {
     try {
       const code = memoryFs.readFileSync(filePath, 'utf8');
       return code;
@@ -33,13 +35,18 @@ export default function registerInMemoryCompiler(compiler: Compiler): void {
   };
 
   // install require hook to be able to require webpack bundles from memory
-  registerRequireHook('.js', resolveFile);
+  const unmountHook = registerRequireHook('.js', resolveFile);
 
   // install source map support to read source map from memory
   sourceMapSupport.install({
     emptyCacheBetweenOperations: true,
     handleUncaughtExceptions: false,
     environment: 'node',
-    retrieveFile: readFile,
+    retrieveFile: (f) => readFile(f), // wrapper function to fake an unmount function
   });
+
+  return function unmount() {
+    unmountHook();
+    readFile = noop;
+  };
 }

--- a/src/webpack/compiler/registerInMemoryCompiler.js
+++ b/src/webpack/compiler/registerInMemoryCompiler.js
@@ -1,3 +1,4 @@
+import path from 'path';
 import sourceMapSupport from 'source-map-support';
 import MemoryFileSystem from 'memory-fs';
 import registerRequireHook from '../util/registerRequireHook';
@@ -16,8 +17,23 @@ export default function registerInMemoryCompiler(compiler: Compiler): void {
     }
   };
 
+  const resolveFile = (filePath, requireCaller) => {
+    // try to read file from memory-fs as it is
+    let code = readFile(filePath);
+
+    if (code === null && requireCaller != null) {
+      const { filename } = requireCaller;
+      if (filename != null) {
+        // if that didn't work, resolve the file relative to it's parent
+        const resolvedPath = path.resolve(path.dirname(filename), filePath);
+        code = readFile(resolvedPath);
+      }
+    }
+    return code;
+  };
+
   // install require hook to be able to require webpack bundles from memory
-  registerRequireHook('.js', readFile);
+  registerRequireHook('.js', resolveFile);
 
   // install source map support to read source map from memory
   sourceMapSupport.install({

--- a/src/webpack/compiler/registerInMemoryCompiler.js
+++ b/src/webpack/compiler/registerInMemoryCompiler.js
@@ -22,16 +22,17 @@ export default function registerInMemoryCompiler(compiler: Compiler): void {
   const resolveFile = (filePath, requireCaller) => {
     // try to read file from memory-fs as it is
     let code = readFile(filePath);
+    let resolvedPath = filePath;
 
     if (code === null && requireCaller != null) {
       const { filename } = requireCaller;
       if (filename != null) {
         // if that didn't work, resolve the file relative to it's parent
-        const resolvedPath = path.resolve(path.dirname(filename), filePath);
+        resolvedPath = path.resolve(path.dirname(filename), filePath);
         code = readFile(resolvedPath);
       }
     }
-    return code;
+    return { path: code !== null ? resolvedPath : null, source: code };
   };
 
   // install require hook to be able to require webpack bundles from memory

--- a/src/webpack/types.js
+++ b/src/webpack/types.js
@@ -13,6 +13,7 @@ export type Compiler = {
   plugin: (hook: string, fn: () => void) => void,
   run: (cb: () => void) => void,
   watch: (watchOptions: {}, cb: () => void) => void,
+  outputFileSystem: any,
 }
 
 /**

--- a/src/webpack/util/registerRequireHook.js
+++ b/src/webpack/util/registerRequireHook.js
@@ -1,4 +1,6 @@
 /*  eslint-disable no-underscore-dangle */
+
+// see https://github.com/nodejs/node/blob/master/lib/module.js
 import Module from 'module';
 
 // the module in which the require() call originated

--- a/src/webpack/util/registerRequireHook.js
+++ b/src/webpack/util/registerRequireHook.js
@@ -6,7 +6,7 @@ import Module from 'module';
 // the module in which the require() call originated
 let requireCaller;
 // all custom registered resolvers
-const pathResolvers = [];
+let pathResolvers = [];
 
 // keep original Module._resolveFilename
 const originalResolveFilename = Module._resolveFilename;
@@ -88,5 +88,14 @@ export default function registerRequireHook(dotExt: string, resolve: (path: stri
 
     // compile javascript module from its source
     module._compile(source, filename);
+  };
+
+  return function unmout() {
+    pathResolvers = pathResolvers.filter((r) => r !== resolvePath);
+    Module._extensions[dotExt] = originalLoader;
+    Object.keys(sourceCache).forEach((path) => {
+      delete require.cache[path];
+      delete sourceCache[path];
+    });
   };
 }

--- a/src/webpack/util/registerRequireHook.js
+++ b/src/webpack/util/registerRequireHook.js
@@ -1,0 +1,90 @@
+/*  eslint-disable no-underscore-dangle */
+import Module from 'module';
+
+// the module in which the require() call originated
+let requireCaller;
+// all custom registered resolvers
+const pathResolvers = [];
+
+// keep original Module._resolveFilename
+const originalResolveFilename = Module._resolveFilename;
+// override Module._resolveFilename
+Module._resolveFilename = function _resolveFilename(...parameters) {
+  const parent = parameters[1];
+  // store require() caller (the module in which this require() call originated)
+  requireCaller = parent;
+  return originalResolveFilename.apply(this, parameters);
+};
+
+// keep original Module._findPath
+const originalFindPath = Module._findPath;
+// override Module._findPath
+Module._findPath = function _findPath(...parameters) {
+  const request = parameters[0];
+
+  // first try to resolve path with original resolver
+  const filename = originalFindPath.apply(this, parameters);
+  if (filename !== false) {
+    return filename;
+  }
+
+  // and when none found try to resolve the path with custom resolvers
+  for (const resolve of pathResolvers) {
+    const resolved = resolve(request, requireCaller);
+    if (typeof resolved !== 'undefined') {
+      return resolved;
+    }
+  }
+
+  return false;
+};
+
+
+export default function registerRequireHook(dotExt: string, resolve: (path: string, parent: Module) => string): void {
+  // cache source code after resolving to avoid another access to the fs
+  const sourceCache = {};
+
+  const resolvePath = (path, parent) => {
+    // get CommonJS module source code for this require() call
+    const source = resolve(path, parent);
+
+    // if no CommonJS module source code returned - skip this require() hook
+    if (source === null) {
+      return void 0;
+    }
+
+    // flush require() cache
+    delete require.cache[path];
+
+    // put the CommonJS module source code into the hash
+    sourceCache[path] = source;
+
+    // return the path to be require()d in order to get the CommonJS module source code
+    return path;
+  };
+
+  const resolveSource = (path) => {
+    const source = sourceCache[path];
+    delete sourceCache[path];
+    return source;
+  };
+
+  pathResolvers.push(resolvePath);
+
+
+  // keep original extension loader
+  const originalLoader = Module._extensions[dotExt];
+  // override extension loader
+  Module._extensions[dotExt] = (module, filename) => {
+    const source = resolveSource(filename, module);
+
+    if (typeof source === 'undefined') {
+      // load the file with the original loader
+      (originalLoader || Module._extensions['.js'])(module, filename);
+      return;
+    }
+
+    // compile javascript module from its source
+    module._compile(source, filename);
+  };
+}

--- a/src/webpack/util/registerSourcemapSupport.js
+++ b/src/webpack/util/registerSourcemapSupport.js
@@ -1,9 +1,0 @@
-import sourceMapSupport from 'source-map-support';
-
-export default function registerSourcemapSupport() {
-  sourceMapSupport.install({
-    emptyCacheBetweenOperations: true,
-    handleUncaughtExceptions: false,
-    environment: 'node',
-  });
-}

--- a/test/integration/cli/code-splitting.test.js
+++ b/test/integration/cli/code-splitting.test.js
@@ -1,0 +1,45 @@
+/* eslint-env node, mocha */
+/* eslint-disable func-names, prefer-arrow-callback, no-loop-func, max-len */
+
+import { assert } from 'chai';
+import path from 'path';
+import { exec } from 'child_process';
+import normalizePath from 'normalize-path';
+
+
+const fixtureDir = path.relative(process.cwd(), path.join(__dirname, 'fixture'));
+const binPath = path.relative(process.cwd(), path.join('bin', '_mocha'));
+
+describe('code-splitting', function () {
+  context('with static require', function () {
+    before(function () {
+      this.passingTest = normalizePath(path.join(fixtureDir, 'code-splitting/test/lazy-load-entry-static.js'));
+      this.webpackConfig = normalizePath(path.join(fixtureDir, 'code-splitting/webpack.config-test.js'));
+    });
+    it('runs successfull test', function (done) {
+      exec(`node ${binPath}  --webpack-config "${this.webpackConfig}" "${this.passingTest}"`, (err, stdout) => {
+        assert.isNull(err);
+        assert.include(stdout, 'entry1.js');
+        assert.include(stdout, 'entry2.js');
+        assert.include(stdout, '1 passing');
+        done();
+      });
+    });
+  });
+
+  context('with dynamic require', function () {
+    before(function () {
+      this.passingTest = normalizePath(path.join(fixtureDir, 'code-splitting/test/lazy-load-entry-dynamic.js'));
+      this.webpackConfig = normalizePath(path.join(fixtureDir, 'code-splitting/webpack.config-test.js'));
+    });
+    it('runs successfull test', function (done) {
+      exec(`node ${binPath}  --webpack-config "${this.webpackConfig}" "${this.passingTest}"`, (err, stdout) => {
+        assert.isNull(err);
+        assert.include(stdout, 'entry1.js');
+        assert.notInclude(stdout, 'entry2.js');
+        assert.include(stdout, '1 passing');
+        done();
+      });
+    });
+  });
+});

--- a/test/integration/cli/fixture/code-splitting/src/entry/entry1.js
+++ b/test/integration/cli/fixture/code-splitting/src/entry/entry1.js
@@ -1,0 +1,3 @@
+/* eslint-disable */
+
+console.log('entry1.js');

--- a/test/integration/cli/fixture/code-splitting/src/entry/entry2.js
+++ b/test/integration/cli/fixture/code-splitting/src/entry/entry2.js
@@ -1,0 +1,3 @@
+/* eslint-disable */
+
+console.log('entry2.js');

--- a/test/integration/cli/fixture/code-splitting/src/lazy-load-entry-dynamic.js
+++ b/test/integration/cli/fixture/code-splitting/src/lazy-load-entry-dynamic.js
@@ -1,0 +1,9 @@
+/* eslint-disable */
+
+
+module.exports = function (name, cb) {
+  require.ensure([], function (require) {
+    var entry1 = require('./entry/' + name);
+    cb();
+  });
+};

--- a/test/integration/cli/fixture/code-splitting/src/lazy-load-entry-static.js
+++ b/test/integration/cli/fixture/code-splitting/src/lazy-load-entry-static.js
@@ -1,0 +1,10 @@
+/* eslint-disable */
+
+
+module.exports = function (cb) {
+  require.ensure([], function (require) {
+    var entry1 = require('./entry/entry1');
+    var entry2 = require('./entry/entry2');
+    cb();
+  });
+};

--- a/test/integration/cli/fixture/code-splitting/test/lazy-load-entry-dynamic.js
+++ b/test/integration/cli/fixture/code-splitting/test/lazy-load-entry-dynamic.js
@@ -1,0 +1,10 @@
+/* eslint-disable */
+
+var assert = require('assert');
+var lazyLoadEntry = require('../src/lazy-load-entry-dynamic');
+
+describe('lazy-load-entry-dynamic', function () {
+  it('runs test', function (cb) {
+    lazyLoadEntry('entry1', cb);
+  });
+});

--- a/test/integration/cli/fixture/code-splitting/test/lazy-load-entry-static.js
+++ b/test/integration/cli/fixture/code-splitting/test/lazy-load-entry-static.js
@@ -1,0 +1,10 @@
+/* eslint-disable */
+
+var assert = require('assert');
+var lazyLoadEntry = require('../src/lazy-load-entry-static');
+
+describe('lazy-load-entry-static', function () {
+  it('runs test', function (cb) {
+    lazyLoadEntry(cb);
+  });
+});

--- a/test/integration/cli/fixture/code-splitting/webpack.config-test.js
+++ b/test/integration/cli/fixture/code-splitting/webpack.config-test.js
@@ -1,0 +1,5 @@
+/* eslint-disable */
+
+module.exports = {
+  target: 'node'
+};


### PR DESCRIPTION
All webpack assets are now handled by an in memory filesystem as suggested in #25. No files are written to disk.

How does it work?
- all compiled files by webpack are stored in [memory-fs](https://github.com/webpack/memory-fs)
- we hook into the path resolution algorithm of all require calls to look also for file existence in the memory-fs
- we hook into the compile algorithm of all require calls to read the bundle from memory

At the moment this works only for `.js` files, cause we need to register each file extension manually. But this should be fine as nodejs only understands `.js`, `.json` and `.node` files and as far as I know webpack emits only `.js` files. 

Tasks:
- [x] write bundle to memory
- [x] read bundle to memory
- [x] compatibility with sourcemaps
- [x] integration tests for code splitting
- [x] debug support for IDE's (works fine with Webstorm, VS Code works only with `debugger` statements)
- [x] clean up all hooks when ready