### PR TITLE
support custom reporter for mocha

### DIFF
--- a/src/runner/configureMocha.js
+++ b/src/runner/configureMocha.js
@@ -1,4 +1,5 @@
 import Mocha from 'mocha';
+import loadReporter from './loadReporter';
 import type { MochaWebpackOptions } from '../MochaWebpack';
 
 
@@ -10,7 +11,8 @@ export default function configureMocha(options: MochaWebpackOptions) {
   const mocha = new Mocha();
 
   // reporter
-  mocha.reporter(options.reporter, options.reporterOptions);
+  const reporter = loadReporter(options.reporter, options.cwd);
+  mocha.reporter(reporter, options.reporterOptions);
 
   // colors
   mocha.useColors(options.colors);

--- a/src/runner/loadReporter.js
+++ b/src/runner/loadReporter.js
@@ -1,0 +1,24 @@
+import path from 'path';
+import { reporters } from 'mocha';
+
+export default function loadReporter(reporter: string | () => void, cwd: string) {
+  // if reporter is already loaded, just return it
+  if (typeof reporter === 'function') {
+    return reporter;
+  }
+
+  // try to load built-in reporter like 'spec'
+  if (typeof reporters[reporter] !== 'undefined') {
+    return reporters[reporter];
+  }
+
+  let loadedReporter = null;
+  try {
+    // try to load reporter from node_modules
+    loadedReporter = require(reporter); // eslint-disable-line global-require
+  } catch (e) {
+    // try to load reporter from cwd
+    loadedReporter = require(path.resolve(cwd, reporter)); // eslint-disable-line global-require
+  }
+  return loadedReporter;
+}

--- a/test/fixture/customMochaReporter.js
+++ b/test/fixture/customMochaReporter.js
@@ -1,0 +1,9 @@
+module.exports = function reporter(runner) {
+  runner.on('start', () => {
+    console.log('customMochaReporter started'); // eslint-disable-line
+  });
+
+  runner.on('end', () => {
+    console.log('customMochaReporter finished'); // eslint-disable-line
+  });
+};

--- a/test/integration/cli/fixture/simple/simple.js
+++ b/test/integration/cli/fixture/simple/simple.js
@@ -1,0 +1,8 @@
+/* eslint-disable */
+var assert = require('assert');
+
+describe('simple test', function () {
+  it('it works', function () {
+    assert.ok(true);
+  });
+});

--- a/test/integration/cli/reporter.test.js
+++ b/test/integration/cli/reporter.test.js
@@ -1,0 +1,30 @@
+/* eslint-env node, mocha */
+/* eslint-disable func-names, prefer-arrow-callback, no-loop-func, max-len */
+
+import { assert } from 'chai';
+import path from 'path';
+import { exec } from 'child_process';
+
+const fixtureDir = path.relative(process.cwd(), path.join(__dirname, 'fixture'));
+const binPath = path.relative(process.cwd(), path.join('bin', '_mocha'));
+const reporter = './test/fixture/customMochaReporter';
+const test = path.join(fixtureDir, 'simple/simple.js');
+
+describe('cli --reporter', function () {
+  it('uses spec reporter', function (done) {
+    exec(`node ${binPath}  --reporter spec "${test}"`, (err, stdout) => {
+      assert.isNull(err);
+      assert.include(stdout, '1 passing');
+      done();
+    });
+  });
+
+  it('uses custom reporter', function (done) {
+    exec(`node ${binPath}  --reporter "${reporter}" "${test}"`, (err, stdout) => {
+      assert.isNull(err);
+      assert.include(stdout, 'customMochaReporter started');
+      assert.include(stdout, 'customMochaReporter finished');
+      done();
+    });
+  });
+});

--- a/test/unit/runner/loadReporter.test.js
+++ b/test/unit/runner/loadReporter.test.js
@@ -1,0 +1,55 @@
+/* eslint-env node, mocha */
+/* eslint-disable func-names, prefer-arrow-callback, no-loop-func, max-len */
+import { assert } from 'chai';
+import spec from 'mocha/lib/reporters/spec';
+import progress from 'mocha/lib/reporters/progress';
+
+import customMochaReporter from '../../fixture/customMochaReporter';
+import loadReporter from '../../../src/runner/loadReporter';
+
+const customMochaReporterPath = require.resolve('../../fixture/customMochaReporter');
+
+describe('loadReporter', function () {
+  it('should allow to use reporter by function', function () {
+    const reporter = loadReporter(spec);
+    assert.strictEqual(reporter, spec, 'should equal reporter');
+  });
+
+  it('should load built-in reporter', function () {
+    const reporter = loadReporter('spec');
+    assert.strictEqual(reporter, spec, 'should equal built-in reporter');
+  });
+
+  it('should load reporter from node_modules', function () {
+    const reporter = loadReporter('mocha/lib/reporters/progress');
+    assert.strictEqual(reporter, progress, 'should equal node_module reporter');
+  });
+
+  it('should load reporter relative from real cwd (1)', function () {
+    const reporter = loadReporter('./test/fixture/customMochaReporter', process.cwd());
+    assert.strictEqual(reporter, customMochaReporter, 'should equal custom reporter');
+  });
+
+  it('should load reporter relative from real cwd (2)', function () {
+    const reporter = loadReporter('test/fixture/customMochaReporter', process.cwd());
+    assert.strictEqual(reporter, customMochaReporter, 'should equal custom reporter');
+  });
+
+  it('should load reporter with relative path from custom cwd', function () {
+    const reporter = loadReporter('../../fixture/customMochaReporter', __dirname);
+    assert.strictEqual(reporter, customMochaReporter, 'should equal custom reporter');
+  });
+
+  it('should load reporter with absolute path', function () {
+    const reporter = loadReporter(customMochaReporterPath, process.cwd());
+    assert.strictEqual(reporter, customMochaReporter, 'should equal custom reporter');
+  });
+
+  it('throws error when not found', function () {
+    const load = () => {
+      loadReporter('xxx/xxxx/xxxx/test.js', process.cwd());
+    };
+
+    assert.throws(load, /Cannot find module/);
+  });
+});


### PR DESCRIPTION
This PR adds support for custom or third-party reporters:
- use custom reporter as function (API only)
- use built-in reporter (like 'spec')
- use custom reporter from node_modules
- use custom reporter relative from cwd

Ref: #58