### PR TITLE
export factory function to use mocha-webpack programmatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "bin": {
     "mocha-webpack": "./bin/mocha-webpack"
   },
+  "main": "./lib/createMochaWebpack.js",
   "files": [
     "*.md",
     "bin",

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -6,7 +6,7 @@ import { existsFileSync } from '../util/exists';
 import parseConfig from './parseConfig';
 import requireWebpackConfig from './requireWebpackConfig';
 import { ensureGlob, extensionsToGlob } from '../util/glob';
-import MochaWebpack from '../MochaWebpack';
+import createMochaWebpack from '../createMochaWebpack';
 
 
 function resolve(mod) {
@@ -39,7 +39,7 @@ options.include = options.include.map(resolve);
 
 options.webpackConfig = requireWebpackConfig(options.webpackConfig);
 
-const mochaWebpack = new MochaWebpack();
+const mochaWebpack = createMochaWebpack();
 
 options.include.forEach((f) => mochaWebpack.addInclude(f));
 

--- a/src/createMochaWebpack.js
+++ b/src/createMochaWebpack.js
@@ -1,0 +1,7 @@
+// @flow
+import MochaWebpack from './MochaWebpack';
+
+// module.exports cause of babel 6
+module.exports = function createMochaWebpack(): MochaWebpack {
+  return new MochaWebpack();
+};

--- a/test/unit/createMochaWebpack.test.js
+++ b/test/unit/createMochaWebpack.test.js
@@ -1,0 +1,15 @@
+/* eslint-env node, mocha */
+/* eslint-disable func-names, prefer-arrow-callback, no-loop-func, max-len */
+import { assert } from 'chai';
+import MochaWebpack from '../../src/MochaWebpack';
+import createMochaWebpack from '../../src/createMochaWebpack';
+
+describe('createMochaWebpack', function () {
+  it('should create a instance of MochaWebpack', function () {
+    assert.doesNotThrow(() => createMochaWebpack());
+    const mochaWebpack = createMochaWebpack();
+
+    assert.isNotNull(mochaWebpack);
+    assert.instanceOf(mochaWebpack, MochaWebpack);
+  });
+});


### PR DESCRIPTION
Export a factory function instead of the main class as nobody should rely on inheritance. 