### PR TITLE
mocha hangs in watch mode with disabled timeouts

### DIFF
--- a/src/runner/TestRunner.js
+++ b/src/runner/TestRunner.js
@@ -119,6 +119,13 @@ export default class TestRunner {
       runAgain = true;
       if (mochaRunner) {
         mochaRunner.abort();
+        // make sure that the current running test will be aborted when timeouts are disabled for async tests
+        if (mochaRunner.currentRunnable) {
+          mochaRunner.currentRunnable.retries(0);
+          mochaRunner.currentRunnable.enableTimeouts(true);
+          mochaRunner.currentRunnable.timeout(1);
+          mochaRunner.currentRunnable.resetTimeout(1);
+        }
       } else {
         runMocha();
       }


### PR DESCRIPTION
Never ending async tests (done callback gets never called) let mocha hang in watch mode when timeouts are disabled. We need to make sure that all tests gets canceled before we can re-run mocha again.

Example:

```
$ mocha-webpack --timeouts 0 --watch test.js
```

**test.js**
```javascript
var assert = require('assert');
describe('test', function () {
  it('runs test', function (done) {
    console.log('this will never finish');
  });
});
```