### PR TITLE
check if module is already marked as affected

### DIFF
--- a/src/webpack/util/getAffectedModuleIds.js
+++ b/src/webpack/util/getAffectedModuleIds.js
@@ -14,6 +14,10 @@ const isBuilt = (module: Module): boolean => module.built;
 const getId = (module: Module): number => module.id;
 
 const affectedModules = (map: ModuleMap, usageMap: ModuleUsageMap, affected: ModuleMap, moduleId: string): void => {
+  if (typeof affected[moduleId] !== 'undefined') {
+    // module was already inspected, stop here otherwise we get into endless recursion
+    return;
+  }
   // module is identified as affected by this function call
   const module = map[moduleId];
   affected[module.id] = module;  // eslint-disable-line no-param-reassign

--- a/test/integration/cli/code-splitting.test.js
+++ b/test/integration/cli/code-splitting.test.js
@@ -43,6 +43,23 @@ describe('code-splitting', function () {
     });
   });
 
+  context('with dynamic require (self referencing require statements)', function () {
+    before(function () {
+      this.passingTest = normalizePath(path.join(fixtureDir, 'code-splitting/test/cyclic-load-entry.js'));
+      this.webpackConfig = normalizePath(path.join(fixtureDir, 'code-splitting/webpack.config-test.js'));
+    });
+
+    it('runs successfull test with cylic dependencies (entry matches itself)', function (done) {
+      exec(`node ${binPath}  --webpack-config "${this.webpackConfig}" "${this.passingTest}"`, (err, stdout) => {
+        assert.isNull(err);
+        assert.include(stdout, 'entry1.js');
+        assert.notInclude(stdout, 'entry2.js');
+        assert.include(stdout, '1 passing');
+        done();
+      });
+    });
+  });
+
   context('without any require statements (empty require.ensure)', function () {
     before(function () {
       this.passingTest = normalizePath(path.join(fixtureDir, 'code-splitting/test/lazy-load-none.js'));

--- a/test/integration/cli/fixture/code-splitting/src/cyclic/entry1.js
+++ b/test/integration/cli/fixture/code-splitting/src/cyclic/entry1.js
@@ -1,0 +1,3 @@
+/* eslint-disable */
+
+console.log('entry1.js');

--- a/test/integration/cli/fixture/code-splitting/src/cyclic/entry2.js
+++ b/test/integration/cli/fixture/code-splitting/src/cyclic/entry2.js
@@ -1,0 +1,3 @@
+/* eslint-disable */
+
+console.log('entry2.js');

--- a/test/integration/cli/fixture/code-splitting/src/cyclic/index.js
+++ b/test/integration/cli/fixture/code-splitting/src/cyclic/index.js
@@ -1,0 +1,8 @@
+/* eslint-disable */
+
+module.exports = function (name, cb) {
+    require.ensure([], function (require) {
+        require('./' + name);
+        cb();
+    });
+};

--- a/test/integration/cli/fixture/code-splitting/test/cyclic-load-entry.js
+++ b/test/integration/cli/fixture/code-splitting/test/cyclic-load-entry.js
@@ -1,0 +1,10 @@
+/* eslint-disable */
+
+var assert = require('assert');
+var loadCyclic = require('../src/cyclic');
+
+describe('cyclic-load-dependency', function () {
+  it('runs test', function (cb) {
+    loadCyclic('entry1', cb);
+  });
+});


### PR DESCRIPTION
This prevents an error with an cyclic require statement that matches the file itself.