### PR TITLE
make sure mocha callback is only called once

### DIFF
--- a/src/runner/TestRunner.js
+++ b/src/runner/TestRunner.js
@@ -110,7 +110,7 @@ export default class TestRunner {
         process.removeListener('uncaughtException', uncaughtExceptionListener);
 
         // run tests
-        mochaRunner = mocha.run(() => {
+        mochaRunner = mocha.run(_.once(() => {
           // register custom exception handler to catch all errors that may happen after mocha think tests are done
           process.on('uncaughtException', uncaughtExceptionListener);
 
@@ -122,7 +122,7 @@ export default class TestRunner {
               compilationScheduler = null;
             }
           });
-        });
+        }));
       } catch (err) {
         console.error('An exception occurred while loading tests: %s', err.message); // eslint-disable-line no-console
         console.error(err.stack); // eslint-disable-line no-console


### PR DESCRIPTION
Mocha calls the callback in rare cases twice when we abort tests and this means that we register the exception handler also twice.