### PR TITLE
Fix --watch issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   - WEBPACK_VERSION=beta MOCHA_VERSION=3
 
 before_script:
-  - "npm install webpack@$WEBPACK_VERSION"
+  - if [ "${WEBPACK_VERSION}" != "1" ]; then npm install "webpack@$WEBPACK_VERSION"; fi
   - "npm install mocha@$MOCHA_VERSION"
 
 script:

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "chai": "^3.5.0",
     "coffee-script": "^1.11.1",
     "cross-env": "^3.1.3",
-    "cross-spawn-with-kill": "^1.0.0",
     "del": "^2.2.0",
     "del-cli": "^0.2.0",
     "eslint": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "chai": "^3.5.0",
     "coffee-script": "^1.11.1",
     "cross-env": "^3.1.3",
+    "cross-spawn-with-kill": "^1.0.0",
     "del": "^2.2.0",
     "del-cli": "^0.2.0",
     "eslint": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "np": "^2.9.0",
     "nyc": "^10.0.0",
     "sinon": "^1.17.3",
-    "webpack": "^1.12.13"
+    "webpack": "zinserjan/webpack#webpack-1"
   },
   "dependencies": {
     "babel-runtime": "^6.18.0",

--- a/src/webpack/loader/entryLoader.js
+++ b/src/webpack/loader/entryLoader.js
@@ -1,5 +1,6 @@
 // @flow
 import loaderUtils from 'loader-utils';
+import normalizePath from 'normalize-path';
 import createEntry from '../util/createEntry';
 
 const KEY = Symbol('entryConfig');
@@ -13,11 +14,13 @@ class EntryConfig {
   }
 
   addFile(file: string): void {
-    this.files.push(file);
+    const normalizedFile = normalizePath(file);
+    this.files.push(normalizedFile);
   }
 
   removeFile(file: string): void {
-    this.files = this.files.filter((f) => f !== file);
+    const normalizedFile = normalizePath(file);
+    this.files = this.files.filter((f) => f !== normalizedFile);
   }
 
   getFiles(): Array<string> {

--- a/src/webpack/loader/entryLoader.js
+++ b/src/webpack/loader/entryLoader.js
@@ -27,10 +27,6 @@ class EntryConfig {
 }
 
 const entryLoader = function entryLoader() {
-  if (this.cacheable) {
-    this.cacheable();
-  }
-
   const config: EntryConfig = this.options[KEY];
 
   // Remove all dependencies of the loader result

--- a/test/integration/cli/watch.test.js
+++ b/test/integration/cli/watch.test.js
@@ -396,7 +396,7 @@ describe('cli --watch', function () {
       });
   });
 
-  it('should abort tests suite when a file changes while running tests and then test again', function () {
+  it('should abort test suite when a file changes while running tests and then test again', function () {
     this.timeout(15000);
     const testFile = 'test1.js';
     const testId = Date.now();
@@ -419,13 +419,12 @@ describe('cli --watch', function () {
         // update test
         createLongRunningTest(testFile, updatedTestId);
       })
-      // wait until tests were aborted
-      .then(() => waitFor(() => mw.log.includes('1 failing'), 3000))
+      // wait until tests were aborted, it can happen that a test is marked as failed or as passed
+      // dependent on the time when the test was aborted...
+      .then(() => waitFor(() => mw.log.includes('1 failing') || mw.log.includes('1 passing'), 3000))
       .then(() => {
         // check if tests were aborted
         assert.notInclude(mw.log, `finished ${testId} - 2`);
-        assert.include(mw.log, '0 passing', 'test suite should abort current async test');
-        assert.include(mw.log, '1 failing', 'test suite should mark async test as failed');
       })
       // wait until tests were tested again
       .then(() => waitFor(() => mw.log.includes(`finished ${updatedTestId}`) && mw.log.includes('2 passing'), 7000))
@@ -600,7 +599,7 @@ describe('cli --watch', function () {
         mw.clearLog();
 
         // delete test
-        return deleteTest(testFile2);
+        deleteTest(testFile2);
       })
       // wait until the output matches our condition
       .then(() => waitFor(() => mw.log.includes('0 passing'), 5000))

--- a/test/integration/cli/watch.test.js
+++ b/test/integration/cli/watch.test.js
@@ -3,16 +3,13 @@
 
 import { assert } from 'chai';
 import path from 'path';
-import { spawn } from 'child_process';
+import spawn from 'cross-spawn-with-kill';
 import del from 'del';
 import fs from 'fs-extra';
 
 const fixtureDir = path.join(process.cwd(), '.tmp/fixture');
-const binPath = path.relative(process.cwd(), path.join('bin', '_mocha'));
 
-const deleteTest = (fileName) => {
-  fs.unlinkSync(path.join(fixtureDir, fileName));
-};
+const deleteTest = (fileName) => del(path.join(fixtureDir, fileName));
 
 const createTest = (fileName, testName, passing) => {
   const content = `
@@ -97,18 +94,52 @@ const createNeverEndingTest = (fileName, testName) => {
   fs.outputFileSync(path.join(fixtureDir, fileName), content);
 };
 
-const waitUntil = (condition, fn, timeout) => {
-  const start = Date.now();
+
+const pause = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const waitFor = (condition, timeoutInMs) => new Promise((resolve, reject) => {
+  const startTime = Date.now();
+  const endTime = startTime + timeoutInMs;
+
+  const remainingTime = () => Math.max(endTime - Date.now(), 0);
+  const timeoutDelay = () => Math.min(remainingTime(), 50);
+
   const run = () => {
     if (condition()) {
-      setTimeout(() => fn(true), 100); // delay execution
-    } else if (Date.now() < start + timeout) {
-      setTimeout(run, 10);
+      resolve();
+    } else if (remainingTime() > 0) {
+      setTimeout(run, timeoutDelay());
     } else {
-      fn(false);
+      reject(new Error(`Condition not met within time: ${condition.toString()}`));
     }
   };
-  setTimeout(run, 10);
+  setTimeout(run, timeoutDelay());
+});
+
+const spawnMochaWebpack = (...args) => {
+  let data = '';
+  const binPath = path.relative(process.cwd(), path.join('bin', 'mocha-webpack'));
+
+  const child = spawn('node', [binPath, ...args]);
+  const receiveData = (d) => {
+    data += d.toString();
+  };
+
+  child.stdout.on('data', receiveData);
+  child.stderr.on('data', receiveData);
+
+  return {
+    get log() {
+      return data;
+    },
+    clearLog() {
+      data = '';
+    },
+    kill() {
+      child.stdout.removeListener('data', receiveData);
+      child.stderr.removeListener('data', receiveData);
+      child.kill();
+    },
+  };
 };
 
 
@@ -118,506 +149,475 @@ describe('cli --watch', function () {
     this.entryGlob = path.relative(process.cwd(), this.testGlob);
   });
 
-  it('should log syntax error and wait until that is fixed before running tests', function (done) {
-    this.timeout(15000);
+  it('should log syntax error and wait until that is fixed before running tests', function () {
+    this.timeout(10000);
     const testFile = 'test1.js';
     const testId = Date.now();
     createSyntaxErrorTest(testFile, testId);
+    const mw = spawnMochaWebpack('--watch', this.entryGlob);
 
-    let data = '';
-    const ls = spawn('node', [binPath, '--watch', this.entryGlob]);
-    const receiveData = (d) => {
-      data += d;
-    };
+    return Promise
+      .resolve()
+      // wait until the output matches our condition
+      .then(() => waitFor(() => mw.log.includes('Unexpected token'), 5000))
+      // output matched our condition
+      .then(() => {
+        assert.notInclude(mw.log, testId);
+        assert.notInclude(mw.log, 'failing');
+        assert.notInclude(mw.log, 'passing');
 
-    ls.stdout.on('data', receiveData);
-    ls.stderr.on('data', receiveData);
+        // clear log to receive only changes
+        mw.clearLog();
 
-    // wait for initial test
-    waitUntil(() => data.includes('Unexpected token'), (condition1) => {
-      assert.isTrue(condition1, 'expected condition1 should be true');
-      assert.notInclude(data, testId);
-      assert.notInclude(data, 'failing');
-      assert.notInclude(data, 'passing');
-
-      // reset data to receive only changes
-      data = '';
-
-      // update test
-      const updatedTestId = Date.now();
-      waitUntil(() => data.includes('passing'), (condition2) => {
-        assert.isTrue(condition2, 'expected condition2 should be true');
-
-        // check if fixed test was tested
-        assert.notInclude(data, testId);
-        assert.include(data, updatedTestId);
-        assert.include(data, '1 passing');
-
-        // kill watch process
-        ls.kill();
-        done();
-      }, 5000);
-      createTest(testFile, updatedTestId, true);
-    }, 5000);
+        // fix test
+        const updatedTestId = testId + 100;
+        createTest(testFile, updatedTestId, true);
+        return updatedTestId;
+      })
+      // wait until the output matches our condition
+      .then((updatedTestId) => waitFor(() => mw.log.includes(updatedTestId) && mw.log.includes('1 passing'), 5000))
+      // output matched our condition
+      .then(() => {
+        // check if test was updated
+        assert.notInclude(mw.log, testId);
+      })
+      .catch((e) => e)
+      .then((e) => {
+        // finally, kill watch process
+        mw.kill();
+        if (e) {
+          console.log(mw.log); // eslint-disable-line
+        }
+        // maybe rethrow error
+        assert.ifError(e);
+      });
   });
 
-  it('should catch other errors outside of tests', function (done) {
-    this.timeout(15000);
+  it('should catch other errors outside of tests', function () {
+    this.timeout(10000);
     const testFile = 'test1.js';
     const testId = Date.now();
     createErrorFile(testFile, testId);
+    const mw = spawnMochaWebpack('--watch', this.entryGlob);
 
-    let data = '';
-    const ls = spawn('node', [binPath, '--watch', this.entryGlob]);
-    const receiveData = (d) => {
-      data += d;
-    };
+    return Promise
+      .resolve()
+      // wait until the output matches our condition
+      .then(() => waitFor(() => mw.log.includes(`Error ${testFile}`), 5000))
+      // output matched our condition
+      .then(() => {
+        assert.include(mw.log, 'Exception occurred while loading your tests');
+        assert.include(mw.log, testId);
+        assert.notInclude(mw.log, 'passing');
+        assert.notInclude(mw.log, 'failing');
 
-    ls.stdout.on('data', receiveData);
-    ls.stderr.on('data', receiveData);
+        // clear log to receive only changes
+        mw.clearLog();
 
-    // wait for initial test
-    waitUntil(() => data.includes(`Error ${testFile}`), (condition1) => {
-      assert.isTrue(condition1, 'expected condition1 should be true');
-      assert.include(data, 'Exception occurred while loading your tests');
-      assert.include(data, testFile);
-      assert.include(data, testId);
-      assert.notInclude(data, 'passing');
-      assert.notInclude(data, 'failing');
-
-      // reset data to receive only changes
-      data = '';
-
-      // update test
-      const updatedTestId = Date.now();
-      waitUntil(() => data.includes('passing'), (condition2) => {
-        assert.isTrue(condition2, 'expected condition2 should be true');
-
-        // check if fixed test was tested
-        assert.notInclude(data, testId);
-        assert.include(data, updatedTestId);
-        assert.include(data, '1 passing');
-
-        // kill watch process
-        ls.kill();
-        done();
-      }, 5000);
-      createTest(testFile, updatedTestId, true);
-    }, 5000);
+        // fix test
+        const updatedTestId = testId + 100;
+        createTest(testFile, updatedTestId, true);
+        return updatedTestId;
+      })
+      // wait until the output matches our condition
+      .then((updatedTestId) => waitFor(() => mw.log.includes(updatedTestId) && mw.log.includes('1 passing'), 5000))
+      // output matched our condition
+      .then(() => {
+        // check if test was updated
+        assert.notInclude(mw.log, testId);
+      })
+      .catch((e) => e)
+      .then((e) => {
+        // finally, kill watch process
+        mw.kill();
+        if (e) {
+          console.log(mw.log); // eslint-disable-line
+        }
+        // maybe rethrow error
+        assert.ifError(e);
+      });
   });
 
-  it('should catch uncaught errors that occur after tests are done', function (done) {
+  it('should catch uncaught errors that occur after tests are done', function () {
     this.timeout(10000);
     const testFile = 'test1.js';
     const testId = Date.now();
     createUncaughtErrorTest(testFile, testId);
+    const mw = spawnMochaWebpack('--watch', this.entryGlob);
 
-    let data = '';
-    const ls = spawn('node', [binPath, '--watch', this.entryGlob]);
-    const receiveData = (d) => {
-      data += d;
-    };
+    return Promise
+      .resolve()
+      // wait until the output matches our condition
+      .then(() => waitFor(() => mw.log.includes('UNCAUGHT EXCEPTION'), 5000))
+      // output matched our condition
+      .then(() => {
+        assert.include(mw.log, 'Exception occurred after running tests');
+        assert.include(mw.log, '1 passing');
+        assert.include(mw.log, testFile);
+        assert.include(mw.log, testId);
 
-    ls.stdout.on('data', receiveData);
-    ls.stderr.on('data', receiveData);
+        // clear log to receive only changes
+        mw.clearLog();
 
-    // wait for initial test
-    waitUntil(() => data.includes('UNCAUGHT EXCEPTION'), (condition1) => {
-      assert.isTrue(condition1, 'expected condition1 should be true');
-      assert.include(data, 'Exception occurred after running tests');
-      assert.include(data, '1 passing');
-
-      assert.include(data, testFile);
-      assert.include(data, testId);
-
-      // reset data to receive only changes
-      data = '';
-
-      // update test to check if process is still alive
-      const updatedTestId = Date.now();
-      waitUntil(() => data.includes('passing'), (condition2) => {
-        assert.isTrue(condition2, 'expected condition2 should be true');
-
-        // check if fixed test was tested
-        assert.notInclude(data, testId);
-        assert.include(data, updatedTestId);
-        assert.include(data, '1 passing');
-
-        // kill watch process
-        ls.kill();
-        done();
-      }, 5000);
-      createTest(testFile, updatedTestId, true);
-    }, 5000);
+        // fix test
+        const updatedTestId = testId + 100;
+        createTest(testFile, updatedTestId, true);
+        return updatedTestId;
+      })
+      // wait until the output matches our condition
+      .then((updatedTestId) => waitFor(() => mw.log.includes(updatedTestId) && mw.log.includes('1 passing'), 5000))
+      // output matched our condition
+      .then(() => {
+        // check if test was updated
+        assert.notInclude(mw.log, testId);
+      })
+      .catch((e) => e)
+      .then((e) => {
+        // finally, kill watch process
+        mw.kill();
+        if (e) {
+          console.log(mw.log); // eslint-disable-line
+        }
+        // maybe rethrow error
+        assert.ifError(e);
+      });
   });
 
-  it('should run a test', function (done) {
-    this.timeout(10000);
+  it('should run a test', function () {
+    this.timeout(5000);
     const testFile = 'test1.js';
     const testId = Date.now();
     createTest(testFile, testId, true);
 
-    let data = '';
-    const ls = spawn('node', [binPath, '--watch', this.entryGlob]);
-    const receiveData = (d) => {
-      data += d;
-    };
+    const mw = spawnMochaWebpack('--watch', this.entryGlob);
 
-    ls.stdout.on('data', receiveData);
-    ls.stderr.on('data', receiveData);
-
-    // wait for initial test
-    waitUntil(() => data.includes(testId), (condition1) => {
-      assert.isTrue(condition1, 'expected condition1 should be true');
-      assert.include(data, testId);
-      assert.include(data, testFile);
-      assert.include(data, '1 passing');
-
-      // kill watch process
-      done();
-      ls.kill();
-    }, 5000);
+    return Promise
+      .resolve()
+      // wait until the output matches our condition
+      .then(() => waitFor(() => mw.log.includes(testId) && mw.log.includes('1 passing'), 5000))
+      .catch((e) => e)
+      .then((e) => {
+        // finally, kill watch process
+        mw.kill();
+        if (e) {
+          console.log(mw.log); // eslint-disable-line
+        }
+        // maybe rethrow error
+        assert.ifError(e);
+      });
   });
 
-  it('should run a test again when it changes', function (done) {
+  it('should run a test again when it changes', function () {
     this.timeout(15000);
     const testFile = 'test1.js';
     const testId = Date.now();
     createTest(testFile, testId, true);
+    const mw = spawnMochaWebpack('--watch', this.entryGlob);
 
-    let data = '';
-    const ls = spawn('node', [binPath, '--watch', this.entryGlob]);
-    const receiveData = (d) => {
-      data += d;
-    };
+    return Promise
+      .resolve()
+      // wait until the output matches our condition
+      .then(() => waitFor(() => mw.log.includes(testId) && mw.log.includes('1 passing'), 5000))
+      // output matched our condition
+      .then(() => {
+        // clear log to receive only changes
+        mw.clearLog();
 
-    ls.stdout.on('data', receiveData);
-    ls.stderr.on('data', receiveData);
-
-    // wait for initial test
-    waitUntil(() => data.includes(testId), (condition1) => {
-      assert.isTrue(condition1, 'expected condition1 should be true');
-      assert.include(data, testId);
-      assert.include(data, testFile);
-      assert.include(data, '1 passing');
-
-      // reset data to receive only changes
-      data = '';
-
-      // update test
-      const updatedTestId = Date.now();
-      waitUntil(() => data.includes(updatedTestId), (condition2) => {
-        assert.isTrue(condition2, 'expected condition2 should be true');
-        // check if updated test was tested again
-        assert.include(data, updatedTestId);
-        assert.include(data, testFile);
-        assert.include(data, '1 passing');
-
-        // kill watch process
-        ls.kill();
-        done();
-      }, 5000);
-      createTest(testFile, updatedTestId, true);
-    }, 5000);
+        // update test
+        const updatedTestId = testId + 100;
+        createTest(testFile, updatedTestId, true);
+        return updatedTestId;
+      })
+      // wait until the output matches our condition
+      .then((updatedTestId) => waitFor(() => mw.log.includes(updatedTestId) && mw.log.includes('1 passing'), 5000))
+      // output matched our condition
+      .then(() => {
+        // check if test was updated
+        assert.notInclude(mw.log, testId);
+      })
+      .catch((e) => e)
+      .then((e) => {
+        // finally, kill watch process
+        mw.kill();
+        if (e) {
+          console.log(mw.log); // eslint-disable-line
+        }
+        // maybe rethrow error
+        assert.ifError(e);
+      });
   });
 
-  it('should run only the changed test again when it changes', function (done) {
+  it('should run only the changed test again when it changes', function () {
     this.timeout(15000);
     const testFile1 = 'test1.js';
     const testFile2 = 'test2.js';
     const testId1 = Date.now() + 1;
-    const testId2 = Date.now() + 2;
+    const testId2 = testId1 + 2;
     createTest(testFile1, testId1, true);
     createTest(testFile2, testId2, true);
+    const mw = spawnMochaWebpack('--watch', this.entryGlob);
 
-    let data = '';
-    const ls = spawn('node', [binPath, '--watch', this.entryGlob]);
-    const receiveData = (d) => {
-      data += d;
-    };
+    return Promise
+      .resolve()
+      // wait until the output matches our condition
+      .then(() => waitFor(() => mw.log.includes('2 passing'), 5000))
+      // output matched our condition
+      .then(() => {
+        // check if both tests were tested
+        assert.include(mw.log, testId1);
+        assert.include(mw.log, testFile1);
+        assert.include(mw.log, testId2);
+        assert.include(mw.log, testFile2);
 
-    ls.stdout.on('data', receiveData);
-    ls.stderr.on('data', receiveData);
+        // clear log to receive only changes
+        mw.clearLog();
 
-    // wait for initial test
-    waitUntil(() => data.includes(testId1), (condition1) => {
-      assert.isTrue(condition1, 'expected condition1 should be true');
-      assert.include(data, testId1);
-      assert.include(data, testFile1);
-      assert.include(data, testId2);
-      assert.include(data, testFile2);
-      assert.include(data, '2 passing');
-
-      // reset data to receive only changes
-      data = '';
-
-      // update test
-      const updatedTestId = Date.now();
-      waitUntil(() => data.includes(updatedTestId), (condition2) => {
-        assert.isTrue(condition2, 'expected condition2 should be true');
-        // check if updated test was tested again
-        assert.include(data, updatedTestId);
-        assert.include(data, testFile2);
-
+        // update test
+        const updatedTestId = testId2 + 100;
+        createTest(testFile2, updatedTestId, true);
+        return updatedTestId;
+      })
+      // wait until the output matches our condition
+      .then((updatedTestId) => waitFor(() => mw.log.includes(updatedTestId) && mw.log.includes('1 passing'), 5000))
+      // output matched our condition
+      .then(() => {
         // check if just updated test was tested again
-        assert.include(data, '1 passing');
-        assert.notInclude(data, testFile1);
-        assert.notInclude(data, testId1);
-
-        // kill watch process
-        ls.kill();
-        done();
-      }, 5000);
-      createTest(testFile2, updatedTestId, true);
-    }, 5000);
+        assert.notInclude(mw.log, testFile1);
+        assert.notInclude(mw.log, testId1);
+      })
+      .catch((e) => e)
+      .then((e) => {
+        // finally, kill watch process
+        mw.kill();
+        if (e) {
+          console.log(mw.log); // eslint-disable-line
+        }
+        // maybe rethrow error
+        assert.ifError(e);
+      });
   });
 
-  it('should abort tests suite when a file changes while running tests and then test again', function (done) {
+  it('should abort tests suite when a file changes while running tests and then test again', function () {
     this.timeout(15000);
     const testFile = 'test1.js';
     const testId = Date.now();
+    const updatedTestId = testId + 100;
     createLongRunningTest(testFile, testId);
+    const mw = spawnMochaWebpack('--watch', this.entryGlob);
 
-    let data = '';
-    const ls = spawn('node', [binPath, '--watch', this.entryGlob]);
-    const receiveData = (d) => {
-      data += d;
-    };
+    return Promise
+      .resolve()
+      // wait until the first async test start
+      .then(() => waitFor(() => mw.log.includes(`starting ${testId} - 1`), 5000))
+      .then(() => {
+        // check if tests were not ready yet
+        assert.notInclude(mw.log, `starting ${testId} - 2`);
+        assert.notInclude(mw.log, `finished ${testId} - 2`);
 
-    ls.stdout.on('data', receiveData);
-    ls.stderr.on('data', receiveData);
+        // clear log to receive only changes
+        mw.clearLog();
 
-    // wait for initial test
-    waitUntil(() => data.includes(`starting ${testId}`), (condition1) => {
-      assert.isTrue(condition1, 'expected condition1 should be true');
-      assert.include(data, testId);
-      assert.include(data, `starting ${testId} - 1`);
-      assert.notInclude(data, `starting ${testId} - 2`);
-      assert.notInclude(data, `finished ${testId} - 2`);
-
-      // reset data to receive only changes
-      data = '';
-
-      // update test
-      const updatedTestId = Date.now();
-      waitUntil(() => data.includes(`finished ${updatedTestId} - 2`), (condition2) => {
-        assert.isTrue(condition2, 'expected condition2 should be true');
-
+        // update test
+        createLongRunningTest(testFile, updatedTestId);
+      })
+      // wait until tests were aborted
+      .then(() => waitFor(() => mw.log.includes('1 failing'), 3000))
+      .then(() => {
         // check if tests were aborted
-        assert.notInclude(data, `finished ${testId} - 2`);
-        assert.include(data, '0 passing', 'test suite should abort current async test');
-        assert.include(data, '1 failing', 'test suite should mark async test as failed');
-
-        // check if updated test was tested again
-        assert.include(data, `starting ${updatedTestId} - 1`);
-        assert.include(data, `finished ${updatedTestId} - 1`);
-        assert.include(data, `starting ${updatedTestId} - 2`);
-        assert.include(data, `finished ${updatedTestId} - 2`);
-        assert.include(data, '2 passing');
-
-        // kill watch process
-        ls.kill();
-        done();
-      }, 6000);
-      createLongRunningTest(testFile, updatedTestId);
-    }, 6000);
+        assert.notInclude(mw.log, `finished ${testId} - 2`);
+        assert.include(mw.log, '0 passing', 'test suite should abort current async test');
+        assert.include(mw.log, '1 failing', 'test suite should mark async test as failed');
+      })
+      // wait until tests were tested again
+      .then(() => waitFor(() => mw.log.includes(`finished ${updatedTestId}`) && mw.log.includes('2 passing'), 7000))
+      .catch((e) => e)
+      .then((e) => {
+        // finally, kill watch process
+        mw.kill();
+        if (e) {
+          console.log(mw.log); // eslint-disable-line
+        }
+        // maybe rethrow error
+        assert.ifError(e);
+      });
   });
 
-  it('should also abort tests that will never finish (e.g. by mistake) when timeouts are disabled and run tests again', function (done) {
+  it('should also abort tests that will never finish (e.g. by mistake) when timeouts are disabled and run tests again', function () {
     this.timeout(15000);
     const testFile = 'test1.js';
     const testId = Date.now();
+    const updatedTestId = testId + 100;
     createNeverEndingTest(testFile, testId);
+    const mw = spawnMochaWebpack('--watch', this.entryGlob);
 
-    let data = '';
-    const ls = spawn('node', [binPath, '--timeout', 0, '--watch', this.entryGlob]);
-    const receiveData = (d) => {
-      data += d;
-    };
+    return Promise
+      .resolve()
+      // wait until the first async test start
+      .then(() => waitFor(() => mw.log.includes(`starting ${testId}`), 5000))
+      .then(() => {
+        // clear log to receive only changes
+        mw.clearLog();
 
-    ls.stdout.on('data', receiveData);
-    ls.stderr.on('data', receiveData);
-
-    // wait for initial test
-    waitUntil(() => data.includes(`starting ${testId}`), (condition1) => {
-      assert.isTrue(condition1, 'expected condition1 should be true');
-      assert.include(data, testId);
-      assert.include(data, `starting ${testId}`);
-      assert.notInclude(data, 'passing');
-      assert.notInclude(data, 'failing');
-
-      // reset data to receive only changes
-      data = '';
-
-      // update test
-      const updatedTestId = Date.now();
-      waitUntil(() => data.includes('1 passing'), (condition2) => {
-        assert.isTrue(condition2, 'expected condition2 should be true');
-
+        // update test
+        createTest(testFile, updatedTestId, true);
+      })
+      // wait until tests were aborted
+      .then(() => waitFor(() => mw.log.includes('1 failing'), 3000))
+      .then(() => {
         // check if tests were aborted
-        assert.include(data, '0 passing', 'test suite should abort current async test');
-        assert.include(data, '1 failing', 'test suite should mark async test as failed');
-
-        // check if updated test was tested again
-        assert.include(data, updatedTestId);
-        assert.include(data, '1 passing');
-
-        // kill watch process
-        ls.kill();
-        done();
-      }, 4000);
-      createTest(testFile, updatedTestId, true);
-    }, 4000);
+        assert.notInclude(mw.log, `finished ${testId} - 2`);
+        assert.include(mw.log, '0 passing', 'test suite should abort current async test');
+        assert.include(mw.log, '1 failing', 'test suite should mark async test as failed');
+      })
+      // wait until tests were tested again
+      .then(() => waitFor(() => mw.log.includes(updatedTestId) && mw.log.includes('1 passing'), 5000))
+      .catch((e) => e)
+      .then((e) => {
+        // finally, kill watch process
+        mw.kill();
+        if (e) {
+          console.log(mw.log); // eslint-disable-line
+        }
+        // maybe rethrow error
+        assert.ifError(e);
+      });
   });
 
-  it('should recognize new test entries that match the pattern', function (done) {
-    this.timeout(15000);
+  it('should recognize new test entries that match the pattern', function () {
+    this.timeout(10000);
     const testFile1 = 'test1.js';
     const testId1 = Date.now() + 1;
+    const testFile2 = 'test2.js';
+    const testId2 = testId1 + 2;
     createTest(testFile1, testId1, true);
+    const mw = spawnMochaWebpack('--watch', this.entryGlob);
 
-    let data = '';
-    const ls = spawn('node', [binPath, '--watch', this.entryGlob]);
-    const receiveData = (d) => {
-      data += d;
-    };
+    return Promise
+      .resolve()
+      // wait until the output matches our condition
+      .then(() => waitFor(() => mw.log.includes(testId1) && mw.log.includes('1 passing'), 5000))
+      // output matched our condition
+      .then(() => {
+        // clear log to receive only changes
+        mw.clearLog();
 
-    ls.stdout.on('data', receiveData);
-    ls.stderr.on('data', receiveData);
-
-    // wait for initial test
-    waitUntil(() => data.includes(testId1), (condition1) => {
-      assert.isTrue(condition1, 'expected condition1 should be true');
-      assert.include(data, testId1);
-      assert.include(data, testFile1);
-      assert.include(data, '1 passing');
-
-      // reset data to receive only changes
-      data = '';
-
-      // create new test
-      const testFile2 = 'test2.js';
-      const testId2 = Date.now() + 2;
-      waitUntil(() => data.includes(testId2), (condition2) => {
-        assert.isTrue(condition2, 'expected condition2 should be true');
-        // check if updated test was tested again
-        assert.include(data, testId2);
-        assert.include(data, testFile2);
-        assert.include(data, '1 passing');
-
-        // check if just already tested test wasn't tested again
-        assert.notInclude(data, testFile1);
-        assert.notInclude(data, testId1);
-
-        // kill watch process
-        ls.kill();
-        done();
-      }, 5000);
-      createTest(testFile2, testId2, true);
-    }, 5000);
+        // create new test
+        createTest(testFile2, testId2, true);
+      })
+      // wait until the output matches our condition
+      .then(() => waitFor(() => mw.log.includes(testId2) && mw.log.includes('1 passing'), 5000))
+      // output matched our condition
+      .then(() => {
+        // check if already tested test wasn't tested again
+        assert.notInclude(mw.log, testFile1);
+        assert.notInclude(mw.log, testId1);
+      })
+      .catch((e) => e)
+      .then((e) => {
+        // finally, kill watch process
+        mw.kill();
+        if (e) {
+          console.log(mw.log); // eslint-disable-line
+        }
+        // maybe rethrow error
+        assert.ifError(e);
+      });
   });
 
-  it('should recognize multiple new test entries that match the pattern', function (done) {
-    this.timeout(15000);
+  it('should recognize multiple new test entries that match the pattern', function () {
+    this.timeout(10000);
     const testFile1 = 'test1.js';
     const testId1 = Date.now() + 1;
+    const testFile2 = 'test2.js';
+    const testId2 = testId1 + 2;
+    const testFile3 = 'test3.js';
+    const testId3 = testId2 + 3;
     createTest(testFile1, testId1, true);
+    const mw = spawnMochaWebpack('--watch', this.entryGlob);
 
-    let data = '';
-    const ls = spawn('node', [binPath, '--watch', this.entryGlob]);
-    const receiveData = (d) => {
-      data += d;
-    };
+    return Promise
+      .resolve()
+      // wait until the output matches our condition
+      .then(() => waitFor(() => mw.log.includes('1 passing'), 5000))
+      // output matched our condition
+      .then(() => {
+        assert.include(mw.log, testId1);
+        assert.include(mw.log, testFile1);
 
-    ls.stdout.on('data', receiveData);
-    ls.stderr.on('data', receiveData);
+        // clear log to receive only changes
+        mw.clearLog();
 
-    // wait for initial test
-    waitUntil(() => data.includes(testId1), (condition1) => {
-      assert.isTrue(condition1, 'expected condition1 should be true');
-      assert.include(data, testId1);
-      assert.include(data, testFile1);
-      assert.include(data, '1 passing');
+        // create new tests
+        createTest(testFile2, testId2, true);
+        createTest(testFile3, testId3, true);
+      })
+      // wait until the output matches our condition
+      .then(() => waitFor(() => mw.log.includes('2 passing'), 5000))
+      // output matched our condition
+      .then(() => {
+        // check if only updated tests were tested again
+        assert.include(mw.log, testFile2);
+        assert.include(mw.log, testId2);
+        assert.include(mw.log, testFile3);
+        assert.include(mw.log, testId3);
 
-      // reset data to receive only changes
-      data = '';
-
-      // create new test
-      const testFile2 = 'test2.js';
-      const testId2 = Date.now() + 2;
-      const testFile3 = 'test3.js';
-      const testId3 = Date.now() + 3;
-      waitUntil(() => data.includes('2 passing'), (condition2) => {
-        assert.isTrue(condition2, 'expected condition2 should be true');
-        // check if updated test was tested again
-        assert.include(data, testFile2);
-        assert.include(data, testId2);
-        assert.include(data, testFile3);
-        assert.include(data, testId3);
-
-        assert.include(data, '2 passing');
-
-        // check if just the created tests were tested
-        assert.notInclude(data, '1 passing');
-        assert.notInclude(data, testFile1);
-        assert.notInclude(data, testId1);
-
-        // kill watch process
-        ls.kill();
-        done();
-      }, 5000);
-      createTest(testFile2, testId2, true);
-      createTest(testFile3, testId3, true);
-    }, 5000);
+        assert.notInclude(mw.log, testFile1);
+        assert.notInclude(mw.log, testId1);
+      })
+      .catch((e) => e)
+      .then((e) => {
+        // finally, kill watch process
+        mw.kill();
+        if (e) {
+          console.log(mw.log); // eslint-disable-line
+        }
+        // maybe rethrow error
+        assert.ifError(e);
+      });
   });
 
-  it('should recognize deleted test entries that match the pattern', function (done) {
-    this.timeout(15000);
+  it('should recognize deleted test entries that match the pattern', function () {
+    this.timeout(12000);
     const testFile1 = 'test1.js';
     const testFile2 = 'test2.js';
     const testId1 = Date.now() + 1;
     const testId2 = Date.now() + 2;
     createTest(testFile1, testId1, true);
     createTest(testFile2, testId2, true);
+    const mw = spawnMochaWebpack('--watch', this.entryGlob);
 
-    // delay this until https://github.com/webpack/watchpack/releases/tag/v1.2.0 gets also into webpack 1
-    // watch events fires for files created before starting watcher...
-    setTimeout(() => {
-      let data = '';
-      const ls = spawn('node', [binPath, '--watch', this.entryGlob]);
-      const receiveData = (d) => {
-        data += d;
-      };
+    return Promise
+      .resolve()
+      // delay this until https://github.com/webpack/watchpack/releases/tag/v1.2.0 gets also into webpack 1
+      // watch events fires for files created before starting watcher...
+      .then(() => pause(1500))
+      // wait until the output matches our condition
+      .then(() => waitFor(() => mw.log.includes('2 passing'), 5000))
+      // output matched our condition
+      .then(() => {
+        assert.include(mw.log, testId1);
+        assert.include(mw.log, testFile1);
+        assert.include(mw.log, testId2);
+        assert.include(mw.log, testFile2);
 
-      ls.stdout.on('data', receiveData);
-      ls.stderr.on('data', receiveData);
+        // clear log to receive only changes
+        mw.clearLog();
 
-      // wait for initial test
-      waitUntil(() => data.includes('2 passing'), (condition1) => {
-        assert.isTrue(condition1, 'expected condition1 should be true');
-        assert.include(data, '2 passing');
-        assert.include(data, testId1);
-        assert.include(data, testFile1);
-        assert.include(data, testId2);
-        assert.include(data, testFile2);
-
-        // reset data to receive only changes
-        data = '';
-
-        // delete new test
-        waitUntil(() => data.includes('0 passing'), (condition2) => {
-          assert.isTrue(condition2, 'expected condition2 should be true');
-          assert.include(data, '0 passing');
-
-          // kill watch process
-          ls.kill();
-          done();
-        }, 5000);
-        setTimeout(() => {
-          deleteTest(testFile2);
-        }, 1000);
-      }, 5000);
-    }, 1000);
+        // delete test
+        return deleteTest(testFile2);
+      })
+      // wait until the output matches our condition
+      .then(() => waitFor(() => mw.log.includes('0 passing'), 5000))
+      .catch((e) => e)
+      .then((e) => {
+        // finally, kill watch process
+        mw.kill();
+        if (e) {
+          console.log(mw.log); // eslint-disable-line
+        }
+        // maybe rethrow error
+        assert.ifError(e);
+      });
   });
 
   afterEach(function () {

--- a/test/integration/cli/watch.test.js
+++ b/test/integration/cli/watch.test.js
@@ -154,42 +154,50 @@ describe('cli --watch', function () {
     const testFile = 'test1.js';
     const testId = Date.now();
     createSyntaxErrorTest(testFile, testId);
-    const mw = spawnMochaWebpack('--watch', this.entryGlob);
 
     return Promise
       .resolve()
-      // wait until the output matches our condition
-      .then(() => waitFor(() => mw.log.includes('Unexpected token'), 5000))
-      // output matched our condition
+      // delay this until https://github.com/webpack/watchpack/releases/tag/v1.2.0 gets also into webpack 1
+      // watch events fires for files created before starting watcher...
+      .then(() => pause(1500))
       .then(() => {
-        assert.notInclude(mw.log, testId);
-        assert.notInclude(mw.log, 'failing');
-        assert.notInclude(mw.log, 'passing');
+        const mw = spawnMochaWebpack('--watch', this.entryGlob);
 
-        // clear log to receive only changes
-        mw.clearLog();
+        return Promise
+          .resolve()
+          // wait until the output matches our condition
+          .then(() => waitFor(() => mw.log.includes('Unexpected token'), 5000))
+          // output matched our condition
+          .then(() => {
+            assert.notInclude(mw.log, testId);
+            assert.notInclude(mw.log, 'failing');
+            assert.notInclude(mw.log, 'passing');
 
-        // fix test
-        const updatedTestId = testId + 100;
-        createTest(testFile, updatedTestId, true);
-        return updatedTestId;
-      })
-      // wait until the output matches our condition
-      .then((updatedTestId) => waitFor(() => mw.log.includes(updatedTestId) && mw.log.includes('1 passing'), 5000))
-      // output matched our condition
-      .then(() => {
-        // check if test was updated
-        assert.notInclude(mw.log, testId);
-      })
-      .catch((e) => e)
-      .then((e) => {
-        // finally, kill watch process
-        mw.kill();
-        if (e) {
-          console.log(mw.log); // eslint-disable-line
-        }
-        // maybe rethrow error
-        assert.ifError(e);
+            // clear log to receive only changes
+            mw.clearLog();
+
+            // fix test
+            const updatedTestId = testId + 100;
+            createTest(testFile, updatedTestId, true);
+            return updatedTestId;
+          })
+          // wait until the output matches our condition
+          .then((updatedTestId) => waitFor(() => mw.log.includes(updatedTestId) && mw.log.includes('1 passing'), 5000))
+          // output matched our condition
+          .then(() => {
+            // check if test was updated
+            assert.notInclude(mw.log, testId);
+          })
+          .catch((e) => e)
+          .then((e) => {
+            // finally, kill watch process
+            mw.kill();
+            if (e) {
+              console.log(mw.log); // eslint-disable-line
+            }
+            // maybe rethrow error
+            assert.ifError(e);
+          });
       });
   });
 
@@ -198,43 +206,51 @@ describe('cli --watch', function () {
     const testFile = 'test1.js';
     const testId = Date.now();
     createErrorFile(testFile, testId);
-    const mw = spawnMochaWebpack('--watch', this.entryGlob);
 
     return Promise
       .resolve()
-      // wait until the output matches our condition
-      .then(() => waitFor(() => mw.log.includes(`Error ${testFile}`), 5000))
-      // output matched our condition
+      // delay this until https://github.com/webpack/watchpack/releases/tag/v1.2.0 gets also into webpack 1
+      // watch events fires for files created before starting watcher...
+      .then(() => pause(1500))
       .then(() => {
-        assert.include(mw.log, 'Exception occurred while loading your tests');
-        assert.include(mw.log, testId);
-        assert.notInclude(mw.log, 'passing');
-        assert.notInclude(mw.log, 'failing');
+        const mw = spawnMochaWebpack('--watch', this.entryGlob);
 
-        // clear log to receive only changes
-        mw.clearLog();
+        return Promise
+          .resolve()
+          // wait until the output matches our condition
+          .then(() => waitFor(() => mw.log.includes(`Error ${testFile}`), 5000))
+          // output matched our condition
+          .then(() => {
+            assert.include(mw.log, 'Exception occurred while loading your tests');
+            assert.include(mw.log, testId);
+            assert.notInclude(mw.log, 'passing');
+            assert.notInclude(mw.log, 'failing');
 
-        // fix test
-        const updatedTestId = testId + 100;
-        createTest(testFile, updatedTestId, true);
-        return updatedTestId;
-      })
-      // wait until the output matches our condition
-      .then((updatedTestId) => waitFor(() => mw.log.includes(updatedTestId) && mw.log.includes('1 passing'), 5000))
-      // output matched our condition
-      .then(() => {
-        // check if test was updated
-        assert.notInclude(mw.log, testId);
-      })
-      .catch((e) => e)
-      .then((e) => {
-        // finally, kill watch process
-        mw.kill();
-        if (e) {
-          console.log(mw.log); // eslint-disable-line
-        }
-        // maybe rethrow error
-        assert.ifError(e);
+            // clear log to receive only changes
+            mw.clearLog();
+
+            // fix test
+            const updatedTestId = testId + 100;
+            createTest(testFile, updatedTestId, true);
+            return updatedTestId;
+          })
+          // wait until the output matches our condition
+          .then((updatedTestId) => waitFor(() => mw.log.includes(updatedTestId) && mw.log.includes('1 passing'), 5000))
+          // output matched our condition
+          .then(() => {
+            // check if test was updated
+            assert.notInclude(mw.log, testId);
+          })
+          .catch((e) => e)
+          .then((e) => {
+            // finally, kill watch process
+            mw.kill();
+            if (e) {
+              console.log(mw.log); // eslint-disable-line
+            }
+            // maybe rethrow error
+            assert.ifError(e);
+          });
       });
   });
 
@@ -243,43 +259,51 @@ describe('cli --watch', function () {
     const testFile = 'test1.js';
     const testId = Date.now();
     createUncaughtErrorTest(testFile, testId);
-    const mw = spawnMochaWebpack('--watch', this.entryGlob);
 
     return Promise
       .resolve()
-      // wait until the output matches our condition
-      .then(() => waitFor(() => mw.log.includes('UNCAUGHT EXCEPTION'), 5000))
-      // output matched our condition
+      // delay this until https://github.com/webpack/watchpack/releases/tag/v1.2.0 gets also into webpack 1
+      // watch events fires for files created before starting watcher...
+      .then(() => pause(1500))
       .then(() => {
-        assert.include(mw.log, 'Exception occurred after running tests');
-        assert.include(mw.log, '1 passing');
-        assert.include(mw.log, testFile);
-        assert.include(mw.log, testId);
+        const mw = spawnMochaWebpack('--watch', this.entryGlob);
 
-        // clear log to receive only changes
-        mw.clearLog();
+        return Promise
+          .resolve()
+          // wait until the output matches our condition
+          .then(() => waitFor(() => mw.log.includes('UNCAUGHT EXCEPTION'), 5000))
+          // output matched our condition
+          .then(() => {
+            assert.include(mw.log, 'Exception occurred after running tests');
+            assert.include(mw.log, '1 passing');
+            assert.include(mw.log, testFile);
+            assert.include(mw.log, testId);
 
-        // fix test
-        const updatedTestId = testId + 100;
-        createTest(testFile, updatedTestId, true);
-        return updatedTestId;
-      })
-      // wait until the output matches our condition
-      .then((updatedTestId) => waitFor(() => mw.log.includes(updatedTestId) && mw.log.includes('1 passing'), 5000))
-      // output matched our condition
-      .then(() => {
-        // check if test was updated
-        assert.notInclude(mw.log, testId);
-      })
-      .catch((e) => e)
-      .then((e) => {
-        // finally, kill watch process
-        mw.kill();
-        if (e) {
-          console.log(mw.log); // eslint-disable-line
-        }
-        // maybe rethrow error
-        assert.ifError(e);
+            // clear log to receive only changes
+            mw.clearLog();
+
+            // fix test
+            const updatedTestId = testId + 100;
+            createTest(testFile, updatedTestId, true);
+            return updatedTestId;
+          })
+          // wait until the output matches our condition
+          .then((updatedTestId) => waitFor(() => mw.log.includes(updatedTestId) && mw.log.includes('1 passing'), 5000))
+          // output matched our condition
+          .then(() => {
+            // check if test was updated
+            assert.notInclude(mw.log, testId);
+          })
+          .catch((e) => e)
+          .then((e) => {
+            // finally, kill watch process
+            mw.kill();
+            if (e) {
+              console.log(mw.log); // eslint-disable-line
+            }
+            // maybe rethrow error
+            assert.ifError(e);
+          });
       });
   });
 
@@ -289,21 +313,28 @@ describe('cli --watch', function () {
     const testId = Date.now();
     createTest(testFile, testId, true);
 
-    const mw = spawnMochaWebpack('--watch', this.entryGlob);
-
     return Promise
       .resolve()
-      // wait until the output matches our condition
-      .then(() => waitFor(() => mw.log.includes(testId) && mw.log.includes('1 passing'), 5000))
-      .catch((e) => e)
-      .then((e) => {
-        // finally, kill watch process
-        mw.kill();
-        if (e) {
-          console.log(mw.log); // eslint-disable-line
-        }
-        // maybe rethrow error
-        assert.ifError(e);
+      // delay this until https://github.com/webpack/watchpack/releases/tag/v1.2.0 gets also into webpack 1
+      // watch events fires for files created before starting watcher...
+      .then(() => pause(1500))
+      .then(() => {
+        const mw = spawnMochaWebpack('--watch', this.entryGlob);
+
+        return Promise
+          .resolve()
+          // wait until the output matches our condition
+          .then(() => waitFor(() => mw.log.includes(testId) && mw.log.includes('1 passing'), 5000))
+          .catch((e) => e)
+          .then((e) => {
+            // finally, kill watch process
+            mw.kill();
+            if (e) {
+              console.log(mw.log); // eslint-disable-line
+            }
+            // maybe rethrow error
+            assert.ifError(e);
+          });
       });
   });
 
@@ -312,38 +343,46 @@ describe('cli --watch', function () {
     const testFile = 'test1.js';
     const testId = Date.now();
     createTest(testFile, testId, true);
-    const mw = spawnMochaWebpack('--watch', this.entryGlob);
 
     return Promise
       .resolve()
-      // wait until the output matches our condition
-      .then(() => waitFor(() => mw.log.includes(testId) && mw.log.includes('1 passing'), 5000))
-      // output matched our condition
+      // delay this until https://github.com/webpack/watchpack/releases/tag/v1.2.0 gets also into webpack 1
+      // watch events fires for files created before starting watcher...
+      .then(() => pause(1500))
       .then(() => {
-        // clear log to receive only changes
-        mw.clearLog();
+        const mw = spawnMochaWebpack('--watch', this.entryGlob);
 
-        // update test
-        const updatedTestId = testId + 100;
-        createTest(testFile, updatedTestId, true);
-        return updatedTestId;
-      })
-      // wait until the output matches our condition
-      .then((updatedTestId) => waitFor(() => mw.log.includes(updatedTestId) && mw.log.includes('1 passing'), 5000))
-      // output matched our condition
-      .then(() => {
-        // check if test was updated
-        assert.notInclude(mw.log, testId);
-      })
-      .catch((e) => e)
-      .then((e) => {
-        // finally, kill watch process
-        mw.kill();
-        if (e) {
-          console.log(mw.log); // eslint-disable-line
-        }
-        // maybe rethrow error
-        assert.ifError(e);
+        return Promise
+          .resolve()
+          // wait until the output matches our condition
+          .then(() => waitFor(() => mw.log.includes(testId) && mw.log.includes('1 passing'), 5000))
+          // output matched our condition
+          .then(() => {
+            // clear log to receive only changes
+            mw.clearLog();
+
+            // update test
+            const updatedTestId = testId + 100;
+            createTest(testFile, updatedTestId, true);
+            return updatedTestId;
+          })
+          // wait until the output matches our condition
+          .then((updatedTestId) => waitFor(() => mw.log.includes(updatedTestId) && mw.log.includes('1 passing'), 5000))
+          // output matched our condition
+          .then(() => {
+            // check if test was updated
+            assert.notInclude(mw.log, testId);
+          })
+          .catch((e) => e)
+          .then((e) => {
+            // finally, kill watch process
+            mw.kill();
+            if (e) {
+              console.log(mw.log); // eslint-disable-line
+            }
+            // maybe rethrow error
+            assert.ifError(e);
+          });
       });
   });
 
@@ -355,45 +394,53 @@ describe('cli --watch', function () {
     const testId2 = testId1 + 2;
     createTest(testFile1, testId1, true);
     createTest(testFile2, testId2, true);
-    const mw = spawnMochaWebpack('--watch', this.entryGlob);
 
     return Promise
       .resolve()
-      // wait until the output matches our condition
-      .then(() => waitFor(() => mw.log.includes('2 passing'), 5000))
-      // output matched our condition
+      // delay this until https://github.com/webpack/watchpack/releases/tag/v1.2.0 gets also into webpack 1
+      // watch events fires for files created before starting watcher...
+      .then(() => pause(1500))
       .then(() => {
-        // check if both tests were tested
-        assert.include(mw.log, testId1);
-        assert.include(mw.log, testFile1);
-        assert.include(mw.log, testId2);
-        assert.include(mw.log, testFile2);
+        const mw = spawnMochaWebpack('--watch', this.entryGlob);
 
-        // clear log to receive only changes
-        mw.clearLog();
+        return Promise
+          .resolve()
+          // wait until the output matches our condition
+          .then(() => waitFor(() => mw.log.includes('2 passing'), 5000))
+          // output matched our condition
+          .then(() => {
+            // check if both tests were tested
+            assert.include(mw.log, testId1);
+            assert.include(mw.log, testFile1);
+            assert.include(mw.log, testId2);
+            assert.include(mw.log, testFile2);
 
-        // update test
-        const updatedTestId = testId2 + 100;
-        createTest(testFile2, updatedTestId, true);
-        return updatedTestId;
-      })
-      // wait until the output matches our condition
-      .then((updatedTestId) => waitFor(() => mw.log.includes(updatedTestId) && mw.log.includes('1 passing'), 5000))
-      // output matched our condition
-      .then(() => {
-        // check if just updated test was tested again
-        assert.notInclude(mw.log, testFile1);
-        assert.notInclude(mw.log, testId1);
-      })
-      .catch((e) => e)
-      .then((e) => {
-        // finally, kill watch process
-        mw.kill();
-        if (e) {
-          console.log(mw.log); // eslint-disable-line
-        }
-        // maybe rethrow error
-        assert.ifError(e);
+            // clear log to receive only changes
+            mw.clearLog();
+
+            // update test
+            const updatedTestId = testId2 + 100;
+            createTest(testFile2, updatedTestId, true);
+            return updatedTestId;
+          })
+          // wait until the output matches our condition
+          .then((updatedTestId) => waitFor(() => mw.log.includes(updatedTestId) && mw.log.includes('1 passing'), 5000))
+          // output matched our condition
+          .then(() => {
+            // check if just updated test was tested again
+            assert.notInclude(mw.log, testFile1);
+            assert.notInclude(mw.log, testId1);
+          })
+          .catch((e) => e)
+          .then((e) => {
+            // finally, kill watch process
+            mw.kill();
+            if (e) {
+              console.log(mw.log); // eslint-disable-line
+            }
+            // maybe rethrow error
+            assert.ifError(e);
+          });
       });
   });
 
@@ -403,42 +450,50 @@ describe('cli --watch', function () {
     const testId = Date.now();
     const updatedTestId = testId + 100;
     createLongRunningTest(testFile, testId);
-    const mw = spawnMochaWebpack('--watch', this.entryGlob);
 
     return Promise
       .resolve()
-      // wait until the first async test start
-      .then(() => waitFor(() => mw.log.includes(`starting ${testId} - 1`), 5000))
+      // delay this until https://github.com/webpack/watchpack/releases/tag/v1.2.0 gets also into webpack 1
+      // watch events fires for files created before starting watcher...
+      .then(() => pause(1500))
       .then(() => {
-        // check if tests were not ready yet
-        assert.notInclude(mw.log, `starting ${testId} - 2`);
-        assert.notInclude(mw.log, `finished ${testId} - 2`);
+        const mw = spawnMochaWebpack('--watch', this.entryGlob);
 
-        // clear log to receive only changes
-        mw.clearLog();
+        return Promise
+          .resolve()
+          // wait until the first async test start
+          .then(() => waitFor(() => mw.log.includes(`starting ${testId} - 1`), 5000))
+          .then(() => {
+            // check if tests were not ready yet
+            assert.notInclude(mw.log, `starting ${testId} - 2`);
+            assert.notInclude(mw.log, `finished ${testId} - 2`);
 
-        // update test
-        createLongRunningTest(testFile, updatedTestId);
-      })
-      // wait until tests were aborted
-      .then(() => waitFor(() => mw.log.includes('1 failing'), 3000))
-      .then(() => {
-        // check if tests were aborted
-        assert.notInclude(mw.log, `finished ${testId} - 2`);
-        assert.include(mw.log, '0 passing', 'test suite should abort current async test');
-        assert.include(mw.log, '1 failing', 'test suite should mark async test as failed');
-      })
-      // wait until tests were tested again
-      .then(() => waitFor(() => mw.log.includes(`finished ${updatedTestId}`) && mw.log.includes('2 passing'), 7000))
-      .catch((e) => e)
-      .then((e) => {
-        // finally, kill watch process
-        mw.kill();
-        if (e) {
-          console.log(mw.log); // eslint-disable-line
-        }
-        // maybe rethrow error
-        assert.ifError(e);
+            // clear log to receive only changes
+            mw.clearLog();
+
+            // update test
+            createLongRunningTest(testFile, updatedTestId);
+          })
+          // wait until tests were aborted
+          .then(() => waitFor(() => mw.log.includes('1 failing'), 3000))
+          .then(() => {
+            // check if tests were aborted
+            assert.notInclude(mw.log, `finished ${testId} - 2`);
+            assert.include(mw.log, '0 passing', 'test suite should abort current async test');
+            assert.include(mw.log, '1 failing', 'test suite should mark async test as failed');
+          })
+          // wait until tests were tested again
+          .then(() => waitFor(() => mw.log.includes(`finished ${updatedTestId}`) && mw.log.includes('2 passing'), 7000))
+          .catch((e) => e)
+          .then((e) => {
+            // finally, kill watch process
+            mw.kill();
+            if (e) {
+              console.log(mw.log); // eslint-disable-line
+            }
+            // maybe rethrow error
+            assert.ifError(e);
+          });
       });
   });
 
@@ -448,38 +503,46 @@ describe('cli --watch', function () {
     const testId = Date.now();
     const updatedTestId = testId + 100;
     createNeverEndingTest(testFile, testId);
-    const mw = spawnMochaWebpack('--watch', this.entryGlob);
 
     return Promise
       .resolve()
-      // wait until the first async test start
-      .then(() => waitFor(() => mw.log.includes(`starting ${testId}`), 5000))
+      // delay this until https://github.com/webpack/watchpack/releases/tag/v1.2.0 gets also into webpack 1
+      // watch events fires for files created before starting watcher...
+      .then(() => pause(1500))
       .then(() => {
-        // clear log to receive only changes
-        mw.clearLog();
+        const mw = spawnMochaWebpack('--watch', this.entryGlob);
 
-        // update test
-        createTest(testFile, updatedTestId, true);
-      })
-      // wait until tests were aborted
-      .then(() => waitFor(() => mw.log.includes('1 failing'), 3000))
-      .then(() => {
-        // check if tests were aborted
-        assert.notInclude(mw.log, `finished ${testId} - 2`);
-        assert.include(mw.log, '0 passing', 'test suite should abort current async test');
-        assert.include(mw.log, '1 failing', 'test suite should mark async test as failed');
-      })
-      // wait until tests were tested again
-      .then(() => waitFor(() => mw.log.includes(updatedTestId) && mw.log.includes('1 passing'), 5000))
-      .catch((e) => e)
-      .then((e) => {
-        // finally, kill watch process
-        mw.kill();
-        if (e) {
-          console.log(mw.log); // eslint-disable-line
-        }
-        // maybe rethrow error
-        assert.ifError(e);
+        return Promise
+          .resolve()
+          // wait until the first async test start
+          .then(() => waitFor(() => mw.log.includes(`starting ${testId}`), 5000))
+          .then(() => {
+            // clear log to receive only changes
+            mw.clearLog();
+
+            // update test
+            createTest(testFile, updatedTestId, true);
+          })
+          // wait until tests were aborted
+          .then(() => waitFor(() => mw.log.includes('1 failing'), 3000))
+          .then(() => {
+            // check if tests were aborted
+            assert.notInclude(mw.log, `finished ${testId} - 2`);
+            assert.include(mw.log, '0 passing', 'test suite should abort current async test');
+            assert.include(mw.log, '1 failing', 'test suite should mark async test as failed');
+          })
+          // wait until tests were tested again
+          .then(() => waitFor(() => mw.log.includes(updatedTestId) && mw.log.includes('1 passing'), 5000))
+          .catch((e) => e)
+          .then((e) => {
+            // finally, kill watch process
+            mw.kill();
+            if (e) {
+              console.log(mw.log); // eslint-disable-line
+            }
+            // maybe rethrow error
+            assert.ifError(e);
+          });
       });
   });
 
@@ -490,37 +553,45 @@ describe('cli --watch', function () {
     const testFile2 = 'test2.js';
     const testId2 = testId1 + 2;
     createTest(testFile1, testId1, true);
-    const mw = spawnMochaWebpack('--watch', this.entryGlob);
 
     return Promise
       .resolve()
-      // wait until the output matches our condition
-      .then(() => waitFor(() => mw.log.includes(testId1) && mw.log.includes('1 passing'), 5000))
-      // output matched our condition
+      // delay this until https://github.com/webpack/watchpack/releases/tag/v1.2.0 gets also into webpack 1
+      // watch events fires for files created before starting watcher...
+      .then(() => pause(1500))
       .then(() => {
-        // clear log to receive only changes
-        mw.clearLog();
+        const mw = spawnMochaWebpack('--watch', this.entryGlob);
 
-        // create new test
-        createTest(testFile2, testId2, true);
-      })
-      // wait until the output matches our condition
-      .then(() => waitFor(() => mw.log.includes(testId2) && mw.log.includes('1 passing'), 5000))
-      // output matched our condition
-      .then(() => {
-        // check if already tested test wasn't tested again
-        assert.notInclude(mw.log, testFile1);
-        assert.notInclude(mw.log, testId1);
-      })
-      .catch((e) => e)
-      .then((e) => {
-        // finally, kill watch process
-        mw.kill();
-        if (e) {
-          console.log(mw.log); // eslint-disable-line
-        }
-        // maybe rethrow error
-        assert.ifError(e);
+        return Promise
+          .resolve()
+          // wait until the output matches our condition
+          .then(() => waitFor(() => mw.log.includes(testId1) && mw.log.includes('1 passing'), 5000))
+          // output matched our condition
+          .then(() => {
+            // clear log to receive only changes
+            mw.clearLog();
+
+            // create new test
+            createTest(testFile2, testId2, true);
+          })
+          // wait until the output matches our condition
+          .then(() => waitFor(() => mw.log.includes(testId2) && mw.log.includes('1 passing'), 5000))
+          // output matched our condition
+          .then(() => {
+            // check if already tested test wasn't tested again
+            assert.notInclude(mw.log, testFile1);
+            assert.notInclude(mw.log, testId1);
+          })
+          .catch((e) => e)
+          .then((e) => {
+            // finally, kill watch process
+            mw.kill();
+            if (e) {
+              console.log(mw.log); // eslint-disable-line
+            }
+            // maybe rethrow error
+            assert.ifError(e);
+          });
       });
   });
 
@@ -533,46 +604,54 @@ describe('cli --watch', function () {
     const testFile3 = 'test3.js';
     const testId3 = testId2 + 3;
     createTest(testFile1, testId1, true);
-    const mw = spawnMochaWebpack('--watch', this.entryGlob);
 
     return Promise
       .resolve()
-      // wait until the output matches our condition
-      .then(() => waitFor(() => mw.log.includes('1 passing'), 5000))
-      // output matched our condition
+      // delay this until https://github.com/webpack/watchpack/releases/tag/v1.2.0 gets also into webpack 1
+      // watch events fires for files created before starting watcher...
+      .then(() => pause(1500))
       .then(() => {
-        assert.include(mw.log, testId1);
-        assert.include(mw.log, testFile1);
+        const mw = spawnMochaWebpack('--watch', this.entryGlob);
 
-        // clear log to receive only changes
-        mw.clearLog();
+        return Promise
+          .resolve()
+          // wait until the output matches our condition
+          .then(() => waitFor(() => mw.log.includes('1 passing'), 5000))
+          // output matched our condition
+          .then(() => {
+            assert.include(mw.log, testId1);
+            assert.include(mw.log, testFile1);
 
-        // create new tests
-        createTest(testFile2, testId2, true);
-        createTest(testFile3, testId3, true);
-      })
-      // wait until the output matches our condition
-      .then(() => waitFor(() => mw.log.includes('2 passing'), 5000))
-      // output matched our condition
-      .then(() => {
-        // check if only updated tests were tested again
-        assert.include(mw.log, testFile2);
-        assert.include(mw.log, testId2);
-        assert.include(mw.log, testFile3);
-        assert.include(mw.log, testId3);
+            // clear log to receive only changes
+            mw.clearLog();
 
-        assert.notInclude(mw.log, testFile1);
-        assert.notInclude(mw.log, testId1);
-      })
-      .catch((e) => e)
-      .then((e) => {
-        // finally, kill watch process
-        mw.kill();
-        if (e) {
-          console.log(mw.log); // eslint-disable-line
-        }
-        // maybe rethrow error
-        assert.ifError(e);
+            // create new tests
+            createTest(testFile2, testId2, true);
+            createTest(testFile3, testId3, true);
+          })
+          // wait until the output matches our condition
+          .then(() => waitFor(() => mw.log.includes('2 passing'), 5000))
+          // output matched our condition
+          .then(() => {
+            // check if only updated tests were tested again
+            assert.include(mw.log, testFile2);
+            assert.include(mw.log, testId2);
+            assert.include(mw.log, testFile3);
+            assert.include(mw.log, testId3);
+
+            assert.notInclude(mw.log, testFile1);
+            assert.notInclude(mw.log, testId1);
+          })
+          .catch((e) => e)
+          .then((e) => {
+            // finally, kill watch process
+            mw.kill();
+            if (e) {
+              console.log(mw.log); // eslint-disable-line
+            }
+            // maybe rethrow error
+            assert.ifError(e);
+          });
       });
   });
 
@@ -584,39 +663,43 @@ describe('cli --watch', function () {
     const testId2 = Date.now() + 2;
     createTest(testFile1, testId1, true);
     createTest(testFile2, testId2, true);
-    const mw = spawnMochaWebpack('--watch', this.entryGlob);
 
     return Promise
       .resolve()
       // delay this until https://github.com/webpack/watchpack/releases/tag/v1.2.0 gets also into webpack 1
       // watch events fires for files created before starting watcher...
       .then(() => pause(1500))
-      // wait until the output matches our condition
-      .then(() => waitFor(() => mw.log.includes('2 passing'), 5000))
-      // output matched our condition
       .then(() => {
-        assert.include(mw.log, testId1);
-        assert.include(mw.log, testFile1);
-        assert.include(mw.log, testId2);
-        assert.include(mw.log, testFile2);
+        const mw = spawnMochaWebpack('--watch', this.entryGlob);
+        return Promise
+          .resolve()
+          // wait until the output matches our condition
+          .then(() => waitFor(() => mw.log.includes('2 passing'), 5000))
+          // output matched our condition
+          .then(() => {
+            assert.include(mw.log, testId1);
+            assert.include(mw.log, testFile1);
+            assert.include(mw.log, testId2);
+            assert.include(mw.log, testFile2);
 
-        // clear log to receive only changes
-        mw.clearLog();
+            // clear log to receive only changes
+            mw.clearLog();
 
-        // delete test
-        return deleteTest(testFile2);
-      })
-      // wait until the output matches our condition
-      .then(() => waitFor(() => mw.log.includes('0 passing'), 5000))
-      .catch((e) => e)
-      .then((e) => {
-        // finally, kill watch process
-        mw.kill();
-        if (e) {
-          console.log(mw.log); // eslint-disable-line
-        }
-        // maybe rethrow error
-        assert.ifError(e);
+            // delete test
+            return deleteTest(testFile2);
+          })
+          // wait until the output matches our condition
+          .then(() => waitFor(() => mw.log.includes('0 passing'), 5000))
+          .catch((e) => e)
+          .then((e) => {
+            // finally, kill watch process
+            mw.kill();
+            if (e) {
+              console.log(mw.log); // eslint-disable-line
+            }
+            // maybe rethrow error
+            assert.ifError(e);
+          });
       });
   });
 


### PR DESCRIPTION
This PR fixes several issues in watch mode
- deleting entry files didn't work on windows
- remove caching flag of entry loader (it's not cacheable cause entries could change from outside of loader)

Attempts to make the tests more stable:
- refactored watch tests with promises
- use webpack 1 fork with updated watchpack 1.2.0 until this gets into webpack 1
- retry watch tests until 4 times