### PR TITLE
restore --growl

### DIFF
--- a/src/MochaWebpack.js
+++ b/src/MochaWebpack.js
@@ -20,7 +20,8 @@ export type MochaWebpackOptions = {
   slow: number,
   asyncOnly: boolean,
   delay: boolean,
-  interactive: boolean
+  interactive: boolean,
+  growl: ?boolean,
 };
 
 export default class MochaWebpack {
@@ -354,6 +355,21 @@ export default class MochaWebpack {
     this.options = {
       ...this.options,
       interactive,
+    };
+    return this;
+  }
+
+  /**
+   * Enable growl notification support
+   *
+   * @public
+   * @param {boolean} growl
+   * @return {MochaWebpack}
+   */
+  growl(): MochaWebpack {
+    this.options = {
+      ...this.options,
+      growl: true,
     };
     return this;
   }

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -94,6 +94,10 @@ if (options.delay) {
   mochaWebpack.delay();
 }
 
+if (options.growl) {
+  mochaWebpack.growl();
+}
+
 Promise
   .resolve()
   .then(() => {

--- a/src/runner/configureMocha.js
+++ b/src/runner/configureMocha.js
@@ -60,10 +60,9 @@ export default function configureMocha(options: MochaWebpackOptions) {
   }
 
   // growl
-  // todo add a way to use this also with webpack errors
-  // if (options.growl) {
-  //   mocha.growl();
-  // }
+  if (options.growl) {
+    mocha.growl();
+  }
 
   // async-only
   if (options.asyncOnly) {

--- a/test/integration/cli/reporter.test.js
+++ b/test/integration/cli/reporter.test.js
@@ -27,4 +27,11 @@ describe('cli --reporter', function () {
       done();
     });
   });
+
+  it('shows notifications with --growl', function (done) {
+    exec(`node ${binPath}  --growl "${test}"`, (err) => {
+      assert.isNull(err);
+      done();
+    });
+  });
 });

--- a/test/unit/MochaWebpack.test.js
+++ b/test/unit/MochaWebpack.test.js
@@ -276,5 +276,17 @@ describe('MochaWebpack', function () {
       assert.notStrictEqual(this.mochaWebpack.options, oldOptions, 'interactive() should not mutate');
       assert.strictEqual(returnValue, this.mochaWebpack, 'api should be chainable');
     });
+
+    it('growl()', function () {
+      const oldOptions = this.mochaWebpack.options;
+      const oldValue = oldOptions.growl;
+      assert.isNotOk(oldValue, 'growl should be falsy');
+
+      const returnValue = this.mochaWebpack.growl();
+
+      assert.propertyVal(this.mochaWebpack.options, 'growl', true, 'growl should be changed to true');
+      assert.notStrictEqual(this.mochaWebpack.options, oldOptions, 'growl() should not mutate');
+      assert.strictEqual(returnValue, this.mochaWebpack, 'api should be chainable');
+    });
   });
 });

--- a/test/unit/runner/configureMocha.test.js
+++ b/test/unit/runner/configureMocha.test.js
@@ -1,0 +1,108 @@
+/* eslint-env node, mocha */
+/* eslint-disable func-names, prefer-arrow-callback, no-loop-func, max-len */
+import { assert } from 'chai';
+import { sandbox } from 'sinon';
+import Mocha from 'mocha';
+
+import configureMocha from '../../../src/runner/configureMocha';
+
+
+describe('configureMocha', function () {
+  beforeEach(function () {
+    this.options = {
+      bail: false,
+      reporter: 'spec',
+      reporterOptions: {},
+      ui: 'bdd',
+      invert: false,
+      ignoreLeaks: true,
+      fullStackTrace: false,
+      useInlineDiffs: false,
+      timeout: 2000,
+      slow: 75,
+      asyncOnly: false,
+      delay: false,
+    };
+    this.sandbox = sandbox.create();
+    this.spyReporter = this.sandbox.spy(Mocha.prototype, 'reporter');
+    this.spyUseColors = this.sandbox.spy(Mocha.prototype, 'useColors');
+    this.spyUseInlineDiffs = this.sandbox.spy(Mocha.prototype, 'useInlineDiffs');
+    this.spyEnableTimeouts = this.sandbox.spy(Mocha.prototype, 'enableTimeouts');
+    this.spyGrep = this.sandbox.spy(Mocha.prototype, 'grep');
+    this.spyGrowl = this.sandbox.spy(Mocha.prototype, 'growl');
+  });
+
+  afterEach(function () {
+    this.sandbox.restore();
+  });
+
+  it('should create a instance of Mocha', function () {
+    const mocha = configureMocha(this.options);
+    assert.instanceOf(mocha, Mocha, 'configureMocha should return a instance of Mocha');
+  });
+
+  it('should call reporter()', function () {
+    configureMocha({
+      ...this.options,
+    });
+
+    const reporter = Mocha.reporters[this.options.reporter];
+
+    assert.isTrue(this.spyReporter.called, 'reporter() should be called');
+    assert.isTrue(this.spyReporter.calledWith(reporter, this.options.reporterOptions));
+  });
+
+  it('should call useColors()', function () {
+    configureMocha({
+      ...this.options,
+    });
+
+    assert.isTrue(this.spyUseColors.called, 'useColors() should be called');
+    assert.isTrue(this.spyUseColors.calledWith(this.options.colors));
+  });
+
+  it('should call useInlineDiffs()', function () {
+    configureMocha({
+      ...this.options,
+    });
+
+    assert.isTrue(this.spyUseInlineDiffs.called, 'useInlineDiffs() should be called');
+    assert.isTrue(this.spyUseInlineDiffs.calledWith(this.options.inlineDiffs));
+  });
+
+  it('should call enableTimeouts()', function () {
+    configureMocha({
+      ...this.options,
+      timeout: 0,
+    });
+
+    assert.isTrue(this.spyEnableTimeouts.called, 'enableTimeouts() should be called');
+    assert.isTrue(this.spyEnableTimeouts.calledWith(false));
+  });
+
+  it('should call grep()', function () {
+    configureMocha({
+      ...this.options,
+      grep: 'dddd',
+      fgrep: 'dddd',
+    });
+
+    assert.isTrue(this.spyGrep.calledTwice, 'grep() should be called');
+  });
+
+  it('should set growl', function () {
+    configureMocha({
+      ...this.options,
+      growl: undefined,
+    });
+
+    assert.isFalse(this.spyGrowl.called, 'growl() should not be called');
+
+    configureMocha({
+      ...this.options,
+      growl: true,
+    });
+
+    assert.isTrue(this.spyGrowl.called, 'growl() should be called');
+  });
+});


### PR DESCRIPTION
Restores mocha' s `--growl` option to show notifications about the test results.