### PR TITLE
Fix typo in Istanbul loader example

### DIFF
--- a/docs/guides/code-coverage.md
+++ b/docs/guides/code-coverage.md
@@ -101,18 +101,18 @@ module.exports = {
           test: /\.(js|ts)/,
           include: path.resolve('src'), // instrument only testing sources with Istanbul, after ts-loader runs
           loader: 'istanbul-instrumenter-loader'
-        }: [],
+      }: [],
+      {
+          test: /.js$/,
+          exclude: /(node_modules|bower_components)/,
+          loader: 'babel-loader',
+      },
+      {
+          test: /\.ts$/,
+          exclude: /(node_modules|bower_components)/,
+          loader: 'ts-loader'
+      }
     ),
-    {
-      test: /.js$/,
-      exclude: /(node_modules|bower_components)/,
-      loader: 'babel-loader',
-    },
-    {
-      test: /\.ts$/,
-      exclude: /(node_modules|bower_components)/,
-      loader: 'ts-loader'
-    }
     // ...
   },
   target: 'node',  // webpack should compile node compatible code


### PR DESCRIPTION
It seems like the closing `)` of the `concat` is miss-placed here.

In the previous example

```
const somethingTrue = true;

var module = {
    loaders: [].concat(
        somethingTrue ? {
	    y: 'y'
	} : [],
    ), // note parens placement
    {
	z: 'z'
    }
}
```
would result in => `Uncaught SyntaxError: Unexpected token '{'`


In this proposed change: 

```
const x = true;

var module = {
    loaders: [].concat(
        somethingTrue ? {
	    y: 'y'
	} : [],
	{
	    x: 'x'
        }
    ) // note parens placement
}

would result in => Object {loaders: Array(2)}
```

Am I missing something in the previous version? 