### PR TITLE
#140: Support webpack.config.js that exports a function

### DIFF
--- a/src/cli/requireWebpackConfig.js
+++ b/src/cli/requireWebpackConfig.js
@@ -91,5 +91,9 @@ export default function requireWebpackConfig(webpackConfig) {
   registerCompiler(interpret.extensions[configExtension]);
   const config = require(configPath); // eslint-disable-line global-require
 
+  if (typeof config === 'function') {
+    return config('test')
+  }
+
   return config.default || config;
 }


### PR DESCRIPTION
Allow mocha-webpack to use a webpack.config.js that exports a function, with 1 arg `env`. This pattern is currently supported in webpack2).

This lets mocha-webpack run something equal to `webpack --env=test`.

example webpack.config.js
```
module.exports = (env = 'dev') => {
  const envConfig = require(`./webpack.${env}.js`)
  return merge.smart(commonConfig, envConfig)
}
```
which would include webpack.test.js, with your test-specific webpack config.