### PR TITLE
Fix loading symlinked webpack configuration.

### DIFF
--- a/src/cli/requireWebpackConfig.js
+++ b/src/cli/requireWebpackConfig.js
@@ -16,7 +16,7 @@ const extensions = Object.keys(interpret.extensions).sort(sortExtensions);
 
 function fileExists(filePath) {
   try {
-    return fs.lstatSync(filePath).isFile();
+    return fs.existsSync(filePath);
   } catch (e) {
     return false;
   }

--- a/test/unit/cli/fixture/webpackConfig/webpack.config-symlink.js
+++ b/test/unit/cli/fixture/webpackConfig/webpack.config-symlink.js
@@ -1,0 +1,1 @@
+webpack.config-test.js

--- a/test/unit/cli/requireWebpackConfig.test.js
+++ b/test/unit/cli/requireWebpackConfig.test.js
@@ -16,6 +16,11 @@ describe('requireWebpackConfig', () => {
     assert.deepEqual(requireWebpackConfig(configPath), expectedConfig);
   });
 
+  (process.platform === 'win32' ? it.skip : it)('requires symlinked config file', () => {
+    const configPath = getConfigPath('.js', 'config-symlink');
+    assert.deepEqual(requireWebpackConfig(configPath), expectedConfig);
+  });
+
   it('requires Babel Webpack config file', () => {
     const configPath = getConfigPath('.babel.js');
     assert.deepEqual(requireWebpackConfig(configPath), expectedConfig);


### PR DESCRIPTION
`fs.Stats#isFile` doesn't return true for symlinked files. This pull request changes the function that is used to detect whether or not the given configuration exists to call `fs.realpathSync` before calling `fs.lstatSync`.