### PR TITLE
add mocha4 support, use mocha4/webpack3 by default in development, re…

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,7 +1,5 @@
 [ignore]
 ./lib/.*
-.*/git/.*
-
 [options]
 module.ignore_non_literal_requires=true
 suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,8 @@ branches:
 language: node_js
 
 node_js:
-  - "5"
+  - "4"
   - "6"
-  - "7"
-  - "8"
 
 env:
   - WEBPACK_VERSION=2 MOCHA_VERSION=2

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,17 @@ branches:
 language: node_js
 
 node_js:
-  - "4"
+  - "5"
   - "6"
+  - "7"
+  - "8"
 
 env:
   - WEBPACK_VERSION=2 MOCHA_VERSION=2
   - WEBPACK_VERSION=2 MOCHA_VERSION=3
   - WEBPACK_VERSION=3 MOCHA_VERSION=3
+  - WEBPACK_VERSION=2 MOCHA_VERSION=4
+  - WEBPACK_VERSION=3 MOCHA_VERSION=4
 
 before_script:
   - "npm install webpack@$WEBPACK_VERSION"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "npm run clean-lib && babel ./src -d lib",
     "lint": "eslint src test bin",
     "flow": "flow",
-    "test": "npm run clean-tmp && npm run build && mocha --timeout 10000 --recursive --compilers js:babel-register \"test/**/*.test.js\"",
+    "test": "npm run clean-tmp && npm run build && mocha --timeout 10000 --recursive --require babel-register \"test/**/*.test.js\"",
     "cover": "cross-env BABEL_ENV=coverage nyc --reporter=lcov --reporter=text npm test",
     "posttest": "npm run lint",
     "docs:clean": "del-cli _book",
@@ -44,7 +44,7 @@
   "author": "Jan-André Zinser",
   "license": "MIT",
   "peerDependencies": {
-    "mocha": "^2.4.5 || ^3.0.0",
+    "mocha": "^2.4.5 || ^3.0.0 || ^4.0.0",
     "webpack": "^2.0.0 || ^3.0.0"
   },
   "devDependencies": {
@@ -79,13 +79,13 @@
     "gh-pages": "^0.12.0",
     "gitbook-cli": "^2.3.0",
     "glob": "7.0.5",
-    "mocha": "^3.0.0",
+    "mocha": "^4.0.0",
     "node-sass": "~4.1.1",
     "np": "^2.9.0",
     "nyc": "^10.0.0",
     "sass-loader": "~6.0.0",
     "sinon": "^1.17.3",
-    "webpack": "^2.0.0"
+    "webpack": "^3.6.0"
   },
   "dependencies": {
     "babel-runtime": "^6.18.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "babel-plugin-transform-runtime": "^6.15.0",
     "babel-preset-es2015": "^6.5.0",
     "babel-register": "^6.5.2",
-    "bdd-lazy-var": "^1.2.1",
+    "bdd-lazy-var": "^1.3.1",
     "chai": "^4.1.0",
     "coffee-script": "^1.11.1",
     "cross-env": "^3.1.3",
@@ -79,13 +79,13 @@
     "gh-pages": "^0.12.0",
     "gitbook-cli": "^2.3.0",
     "glob": "7.0.5",
-    "mocha": "^4.0.0",
+    "mocha": "^4.0.1",
     "node-sass": "~4.1.1",
     "np": "^2.9.0",
     "nyc": "^10.0.0",
     "sass-loader": "~6.0.0",
     "sinon": "^1.17.3",
-    "webpack": "^3.6.0"
+    "webpack": "^3.7.1"
   },
   "dependencies": {
     "babel-runtime": "^6.18.0",


### PR DESCRIPTION
…move unsupported nodejs versions from travis

all tests pass except:

 * `cli --watch should run only the changed test again when it changes` is flaky on both `master` and my branch
 *  i get a ton of `flowtype-errors/show-errors` errors but i get those off of `master` as well so i don't think i caused them. 