### PR TITLE
fix default value for webpack config

### DIFF
--- a/src/cli/parseArgv.js
+++ b/src/cli/parseArgv.js
@@ -171,7 +171,7 @@ const options = {
     describe: 'path to webpack-config file',
     group: BASIC_GROUP,
     requiresArg: true,
-    default: 'webpack-config.js',
+    default: 'webpack.config.js',
   },
   'webpack-env': {
     describe: 'environment passed to the webpack-config, when it is a function',

--- a/test/unit/cli/parseArgv.test.js
+++ b/test/unit/cli/parseArgv.test.js
@@ -805,7 +805,7 @@ describe('parseArgv', function () {
         const parsedArgv = this.parseArgv(argv);
 
         // then
-        assert.propertyVal(parsedArgv, 'webpackConfig', 'webpack-config.js');
+        assert.propertyVal(parsedArgv, 'webpackConfig', 'webpack.config.js');
       });
 
 


### PR DESCRIPTION
use webpack.config.js instead of webpack-config.js to be in sync with documentation and webpack

fixes #185 
fixes #178 