### PR TITLE
fix passing options to loaders

### DIFF
--- a/src/runner/TestRunner.js
+++ b/src/runner/TestRunner.js
@@ -261,18 +261,20 @@ export default class TestRunner extends EventEmitter {
       {
         test: /\.js?$/,
         include: entryPath,
-        loader: includeLoaderPath,
-        options: {
-          include: this.includes,
-        },
-      },
-      {
-        test: /\.js?$/,
-        include: entryPath,
-        loader: entryLoaderPath,
-        options: {
-          entryConfig,
-        },
+        use: [
+          {
+            loader: includeLoaderPath,
+            options: {
+              include: this.includes,
+            },
+          },
+          {
+            loader: entryLoaderPath,
+            options: {
+              entryConfig,
+            },
+          },
+        ],
       }
     );
 

--- a/src/runner/TestRunner.js
+++ b/src/runner/TestRunner.js
@@ -259,8 +259,7 @@ export default class TestRunner extends EventEmitter {
     const userLoaders = _.get(webpackConfig, 'module.rules', _.get(webpackConfig, 'module.loaders', []));
     userLoaders.unshift(
       {
-        test: /\.js$/,
-        include: entryPath,
+        test: entryPath,
         use: [
           {
             loader: includeLoaderPath,

--- a/src/runner/TestRunner.js
+++ b/src/runner/TestRunner.js
@@ -259,7 +259,7 @@ export default class TestRunner extends EventEmitter {
     const userLoaders = _.get(webpackConfig, 'module.rules', _.get(webpackConfig, 'module.loaders', []));
     userLoaders.unshift(
       {
-        test: /\.js?$/,
+        test: /\.js$/,
         include: entryPath,
         use: [
           {

--- a/src/webpack/loader/entryLoader.js
+++ b/src/webpack/loader/entryLoader.js
@@ -3,8 +3,6 @@ import loaderUtils from 'loader-utils';
 import normalizePath from 'normalize-path';
 import createEntry from '../util/createEntry';
 
-const KEY = Symbol('entryConfig');
-
 class EntryConfig {
 
   files: Array<string>;
@@ -30,7 +28,8 @@ class EntryConfig {
 }
 
 const entryLoader = function entryLoader() {
-  const config: EntryConfig = this.options[KEY];
+  const loaderOptions = loaderUtils.getOptions(this);
+  const config: EntryConfig = loaderOptions.entryConfig;
 
   // Remove all dependencies of the loader result
   this.clearDependencies();
@@ -50,6 +49,5 @@ const entryLoader = function entryLoader() {
 
 
 module.exports = entryLoader;
-module.exports.KEY = KEY;
 module.exports.EntryConfig = EntryConfig;
 


### PR DESCRIPTION
fixes #127

Loaders does no longer have access to webpack config. That's why we need to pass all loader options directly to the loader. 