### PR TITLE
Add an option to quiet the informational messages.

### DIFF
--- a/docs/installation/cli-usage.md
+++ b/docs/installation/cli-usage.md
@@ -9,6 +9,7 @@ Options
   --async-only, -A               force all tests to take a callback (async) or return a promise
   --colors, -c                   force enabling of colors
   --interactive                  force interactive mode
+  --quiet, -q                    does not display informational messages
   --growl, -G                    enable growl notification support
   --recursive                    include sub directories
   --reporter, -R                 specify the reporter to use

--- a/src/MochaWebpack.js
+++ b/src/MochaWebpack.js
@@ -22,6 +22,7 @@ export type MochaWebpackOptions = {
   asyncOnly: boolean,
   delay: boolean,
   interactive: boolean,
+  quiet: boolean,
   growl?: boolean,
 };
 
@@ -60,6 +61,7 @@ export default class MochaWebpack {
     asyncOnly: false,
     delay: false,
     interactive: !!((process.stdout: any).isTTY),
+    quiet: false,
   };
 
   /**
@@ -257,6 +259,20 @@ export default class MochaWebpack {
   }
 
   /**
+   * Quiet informational messages.
+   *
+   * @public
+   * @return {MochaWebpack}
+   */
+  quiet(): MochaWebpack {
+    this.options = {
+      ...this.options,
+      quiet: true,
+    };
+    return this;
+  }
+
+  /**
    * Use inline diffs rather than +/-.
    *
    * @public
@@ -386,6 +402,7 @@ export default class MochaWebpack {
     testRunnerReporter({
       eventEmitter: runner,
       interactive: this.options.interactive,
+      quiet: this.options.quiet,
       cwd: this.options.cwd,
     });
     return await runner.run();
@@ -400,6 +417,7 @@ export default class MochaWebpack {
     testRunnerReporter({
       eventEmitter: runner,
       interactive: this.options.interactive,
+      quiet: this.options.quiet,
       cwd: this.options.cwd,
     });
     await runner.watch();

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -77,6 +77,10 @@ if (options.fullTrace) {
   mochaWebpack.fullStackTrace();
 }
 
+if (options.quiet) {
+  mochaWebpack.quiet();
+}
+
 mochaWebpack.useColors(options.colors);
 mochaWebpack.useInlineDiffs(options.inlineDiffs);
 mochaWebpack.timeout(options.timeout);

--- a/src/cli/parseArgv.js
+++ b/src/cli/parseArgv.js
@@ -20,6 +20,13 @@ const options = {
     describe: 'force enabling of colors',
     group: OUTPUT_GROUP,
   },
+  quiet: {
+    alias: 'q',
+    type: 'boolean',
+    default: undefined,
+    describe: 'does not show informational messages',
+    group: OUTPUT_GROUP,
+  },
   interactive: {
     type: 'boolean',
     default: !!(process.stdout.isTTY),

--- a/test/integration/cli/quiet.test.js
+++ b/test/integration/cli/quiet.test.js
@@ -1,0 +1,38 @@
+/* eslint-env node, mocha */
+/* eslint-disable func-names, prefer-arrow-callback, no-loop-func, max-len */
+
+import { assert } from 'chai';
+import path from 'path';
+import { exec } from 'child_process';
+
+const fixtureDir = path.relative(process.cwd(), path.join(__dirname, 'fixture'));
+const binPath = path.relative(process.cwd(), path.join('bin', '_mocha'));
+const test = path.join(fixtureDir, 'simple/simple.js');
+
+describe('cli --quiet', function () {
+  it('shows info messages when not set', function (done) {
+    exec(`node ${binPath} "${test}"`, (err, stdout) => {
+      assert.isNull(err);
+      assert.include(stdout, 'WEBPACK  Compiling...');
+      done();
+    });
+  });
+
+  it('does not show info messages', function (done) {
+    exec(`node ${binPath} --quiet "${test}"`, (err, stdout) => {
+      assert.isNull(err);
+      assert.notInclude(stdout, 'WEBPACK');
+      assert.notInclude(stdout, 'MOCHA');
+      assert.notInclude(stdout, 'successfully');
+      done();
+    });
+  });
+
+  it('still shows mocha output', function (done) {
+    exec(`node ${binPath} --quiet "${test}"`, (err, stdout) => {
+      assert.isNull(err);
+      assert.include(stdout, '1 passing');
+      done();
+    });
+  });
+});

--- a/test/unit/MochaWebpack.test.js
+++ b/test/unit/MochaWebpack.test.js
@@ -31,6 +31,7 @@ describe('MochaWebpack', function () {
       asyncOnly: false,
       delay: false,
       interactive: !!(process.stdout.isTTY),
+      quiet: false,
     };
     assert.deepEqual(mochaWebpack.options, expected);
   });


### PR DESCRIPTION
The new messages from #97 can be a little distracting when you're used to just the output from mocha. This just adds a `--quiet` option to stop showing those messages and return to the output behavior pre 1.0.

I'm open to other implementations...would just like the option to opt out of them.