### PR TITLE
test with node 8 and 9 as well use yarn instead of npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ language: node_js
 node_js:
   - "4"
   - "6"
+  - "8"
+  - "9"
 
 env:
   - WEBPACK_VERSION=2 MOCHA_VERSION=2
@@ -19,8 +21,8 @@ env:
   - WEBPACK_VERSION=3 MOCHA_VERSION=4
 
 before_script:
-  - "npm install webpack@$WEBPACK_VERSION"
-  - "npm install mocha@$MOCHA_VERSION"
+  - "yarn add webpack@$WEBPACK_VERSION"
+  - "yarn add mocha@$MOCHA_VERSION"
 
 script:
   - npm run cover


### PR DESCRIPTION
Add: run ci with node 8 and 9
Fix: due to installing other webpack versions with npm 5 causing errors, I would recommend using yarn instead