### PR TITLE
upgrade yargs to support parsing of negative numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "source-map-support": "^0.5.0",
     "strip-ansi": "^4.0.0",
     "toposort": "^1.0.0",
-    "yargs": "^4.8.0"
+    "yargs": "^6.6.0"
   },
   "nyc": {
     "include": [

--- a/src/cli/parseArgv.js
+++ b/src/cli/parseArgv.js
@@ -1,6 +1,5 @@
 import yargs from 'yargs';
 import _ from 'lodash';
-import { version } from '../../package.json';
 
 const BASIC_GROUP = 'Basic options:';
 const OUTPUT_GROUP = 'Output options:';
@@ -208,7 +207,7 @@ export default function parseArgv(argv, ignoreDefaults = false) {
   const parsedArgs = yargs(argv)
     .help('help')
     .alias('help', 'h', '?')
-    .version(() => version)
+    .version()
     .options(options)
     .strict()
     .argv;

--- a/test/integration/cli/version.test.js
+++ b/test/integration/cli/version.test.js
@@ -14,7 +14,7 @@ describe('cli - version', function () {
   });
 
   it('--version prints the correct version', function (done) {
-    exec(`node ${binPath} --mode development --version`, (err, output) => {
+    exec(`node ${binPath} --version`, (err, output) => {
       assert.isNull(err);
       assert.include(output, this.version);
       done();

--- a/test/unit/cli/parseArgv.test.js
+++ b/test/unit/cli/parseArgv.test.js
@@ -519,8 +519,10 @@ describe('parseArgv', function () {
 
       const parameters = [
         { given: ['--slow', '1000'], expected: 1000 },
+        { given: ['--slow', '-1'], expected: -1 },
         { given: ['--s', '1000'], expected: 1000 },
         { given: ['-s', '1000'], expected: 1000 },
+        { given: ['-s', '-1'], expected: -1 },
       ];
 
       for (const parameter of parameters) {


### PR DESCRIPTION
yargs@6 seems to be the latest version that works without too many changes.
All others fails with 
```
Error: Too many arguments provided. Expected max 2 but received 3.
    at module.exports (C:\workspace\github\mocha-webpack\node_modules\yargs\lib\argsert.js:31:13)
    at Object.Yargs.self.alias (C:\workspace\github\mocha-webpack\node_modules\yargs\yargs.js:244:5)
    at parseArgv (C:\workspace\github\mocha-webpack\lib\cli\parseArgv.js:298:60)
    at Object.<anonymous> (C:\workspace\github\mocha-webpack\lib\cli\index.js:57:42)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Module.require (module.js:596:17)

```
fixes #200 