### PR TITLE
update chokidar

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
   "dependencies": {
     "babel-runtime": "^6.18.0",
     "chalk": "^2.3.0",
-    "chokidar": "^1.6.1",
+    "chokidar": "^2.0.2",
     "glob-parent": "^3.1.0",
     "globby": "^6.1.0",
     "interpret": "^1.0.1",

--- a/src/runner/TestRunner.js
+++ b/src/runner/TestRunner.js
@@ -199,6 +199,7 @@ export default class TestRunner extends EventEmitter {
 
     // webpack enhances watch options, that's why we use them instead
     const watchOptions = watchCompiler.getWatchOptions();
+    const pollingInterval = typeof watchOptions.poll === 'number' ? watchOptions.poll : undefined;
     // create own file watcher for entry files to detect created or deleted files
     const watcher = chokidar.watch(this.entries, {
       cwd: this.options.cwd,
@@ -209,7 +210,8 @@ export default class TestRunner extends EventEmitter {
       ignorePermissionErrors: true,
       ignored: watchOptions.ignored,
       usePolling: watchOptions.poll ? true : undefined,
-      interval: typeof watchOptions.poll === 'number' ? watchOptions.poll : undefined,
+      interval: pollingInterval,
+      binaryInterval: pollingInterval,
     });
 
     const restartWebpackBuild = _.debounce(() => watchCompiler.watch(), watchOptions.aggregateTimeout);


### PR DESCRIPTION
- webpack's watcher uses also chokidar@2, so we should use it to.
- fix polling interval for binary files (handled in the same same as with watchpack)