### PR TITLE
memory fs has priority for require calls

### DIFF
--- a/src/util/registerRequireHook.js
+++ b/src/util/registerRequireHook.js
@@ -26,18 +26,18 @@ const originalFindPath = Module._findPath;
 Module._findPath = function _findPath(...parameters) {
   const request = parameters[0];
 
-  // first try to resolve path with original resolver
-  const filename = originalFindPath.apply(this, parameters);
-  if (filename !== false) {
-    return filename;
-  }
-
-  // and when none found try to resolve the path with custom resolvers
+  // try to resolve the path with custom resolvers
   for (const resolve of pathResolvers) {
     const resolved = resolve(request, requireCaller);
     if (typeof resolved !== 'undefined') {
       return resolved;
     }
+  }
+
+  // and when none found try to resolve path with original resolver
+  const filename = originalFindPath.apply(this, parameters);
+  if (filename !== false) {
+    return filename;
   }
 
   return false;

--- a/src/webpack/compiler/registerInMemoryCompiler.js
+++ b/src/webpack/compiler/registerInMemoryCompiler.js
@@ -15,11 +15,10 @@ export default function registerInMemoryCompiler(compiler: Compiler) {
   const assetMap = new Map();
   compiler.hooks.done.tap('mocha-webpack', (stats: Stats) => {
     assetMap.clear();
-    const outputPath = compiler.options.output.path;
 
     if (!stats.hasErrors()) {
       Object.keys(stats.compilation.assets)
-        .forEach((assetPath) => assetMap.set(ensureAbsolutePath(assetPath, outputPath), true));
+        .forEach((assetPath) => assetMap.set(ensureAbsolutePath(assetPath, compiler.options.output.path), true));
     }
   });
 

--- a/src/webpack/types.js
+++ b/src/webpack/types.js
@@ -19,6 +19,11 @@ export type Compiler = {
   hooks: any,
   fileTimestamps: {},
   contextTimestamps: {},
+  options: {
+    output: {
+      path: string,
+    },
+  },
 }
 
 /**

--- a/test/unit/util/fixture/fakeModule.js
+++ b/test/unit/util/fixture/fakeModule.js
@@ -1,0 +1,2 @@
+
+module.exports = "from-dist";

--- a/test/unit/util/registerRequireHook.test.js
+++ b/test/unit/util/registerRequireHook.test.js
@@ -7,34 +7,34 @@ import fakemodule from './fixture/fakeModule';
 const fakeModulePath = require.resolve('./fixture/fakeModule');
 
 describe('registerRequireHook', function () {
-
   beforeEach(function () {
     delete require.cache[fakeModulePath];
   });
 
   it('requires from disk', function () {
-    const result = require(fakeModulePath);
+    const result = require(fakeModulePath); // eslint-disable-line global-require
     assert.equal(result, fakemodule);
   });
 
   it('requires from memory', function () {
     const dispose = registerRequireHook('.js', (filePath, requireCaller) => {
       if (filePath === fakeModulePath) {
+        const { filename } = requireCaller;
+        assert.equal(filename, __filename);
         return { path: filePath, source: 'module.exports = "from-memory";' };
       }
       return { path: null, source: null };
     });
 
     // module should be read from memory
-    const resultMemory = require(fakeModulePath);
+    const resultMemory = require(fakeModulePath); // eslint-disable-line global-require
     assert.notEqual(resultMemory, fakemodule);
 
     // unregister memory require handler
     dispose();
 
     // module should be read from disk
-    const resultDisk = require(fakeModulePath);
+    const resultDisk = require(fakeModulePath); // eslint-disable-line global-require
     assert.equal(resultDisk, fakemodule);
   });
-
 });

--- a/test/unit/util/registerRequireHook.test.js
+++ b/test/unit/util/registerRequireHook.test.js
@@ -1,0 +1,40 @@
+/* eslint-env node, mocha */
+/* eslint-disable func-names, prefer-arrow-callback, no-loop-func, max-len */
+import { assert } from 'chai';
+import registerRequireHook from '../../../src/util/registerRequireHook';
+
+import fakemodule from './fixture/fakeModule';
+const fakeModulePath = require.resolve('./fixture/fakeModule');
+
+describe('registerRequireHook', function () {
+
+  beforeEach(function () {
+    delete require.cache[fakeModulePath];
+  });
+
+  it('requires from disk', function () {
+    const result = require(fakeModulePath);
+    assert.equal(result, fakemodule);
+  });
+
+  it('requires from memory', function () {
+    const dispose = registerRequireHook('.js', (filePath, requireCaller) => {
+      if (filePath === fakeModulePath) {
+        return { path: filePath, source: 'module.exports = "from-memory";' };
+      }
+      return { path: null, source: null };
+    });
+
+    // module should be read from memory
+    const resultMemory = require(fakeModulePath);
+    assert.notEqual(resultMemory, fakemodule);
+
+    // unregister memory require handler
+    dispose();
+
+    // module should be read from disk
+    const resultDisk = require(fakeModulePath);
+    assert.equal(resultDisk, fakemodule);
+  });
+
+});

--- a/test/unit/util/registerRequireHook.test.js
+++ b/test/unit/util/registerRequireHook.test.js
@@ -1,9 +1,9 @@
 /* eslint-env node, mocha */
-/* eslint-disable func-names, prefer-arrow-callback, no-loop-func, max-len */
+/* eslint-disable func-names, prefer-arrow-callback */
 import { assert } from 'chai';
 import registerRequireHook from '../../../src/util/registerRequireHook';
-
 import fakemodule from './fixture/fakeModule';
+
 const fakeModulePath = require.resolve('./fixture/fakeModule');
 
 describe('registerRequireHook', function () {
@@ -12,7 +12,7 @@ describe('registerRequireHook', function () {
   });
 
   it('requires from disk', function () {
-    const result = require(fakeModulePath); // eslint-disable-line global-require
+    const result = require(fakeModulePath); // eslint-disable-line
     assert.equal(result, fakemodule);
   });
 
@@ -27,14 +27,14 @@ describe('registerRequireHook', function () {
     });
 
     // module should be read from memory
-    const resultMemory = require(fakeModulePath); // eslint-disable-line global-require
+    const resultMemory = require(fakeModulePath); // eslint-disable-line
     assert.notEqual(resultMemory, fakemodule);
 
     // unregister memory require handler
     dispose();
 
     // module should be read from disk
-    const resultDisk = require(fakeModulePath); // eslint-disable-line global-require
+    const resultDisk = require(fakeModulePath); // eslint-disable-line
     assert.equal(resultDisk, fakemodule);
   });
 });


### PR DESCRIPTION
Another attempt of #152 based on the proposal in #163.

The idea is to look for modules on memory fs first as the file could also exist on the real fs. This is especially useful when you use mocha-webpack with a plugin that writes the files from memory-fs to disk for debugging purposes or for something else that needs the files.

First step to solve #203 which needs access to the bundled files to start a webworker.

