### PR TITLE
limit lf endings to text files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,11 @@
-* text eol=lf
+# restore defaults
+* text=auto
+
+# use lf line endings at least for the following files
+*.js text eol=lf
+*.ts text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.opts text eol=lf
+*.coffee text eol=lf
+*.yml text eol=lf


### PR DESCRIPTION
Config from #216 was a bit to strict and affected also binary files like png :see_no_evil:
It's better to use a explicit list for files we want to stay always in lf.

