### PR TITLE
 Respect output settings from webpack config

### DIFF
--- a/docs/installation/webpack-configuration.md
+++ b/docs/installation/webpack-configuration.md
@@ -21,9 +21,8 @@ The reason for this is that webpack isn't able to compile all node_modules like 
 
 *Info*: You can install this plugin with `npm install --save-dev webpack-node-externals`
 
-Maybe you noticed that [entry](https://webpack.github.io/docs/configuration.html#entry), [output.filename](https://webpack.github.io/docs/configuration.html#output-filename) and [output.path](https://webpack.github.io/docs/configuration.html#output-path) are completely missing in this config.
-mocha-webpack does this automatically for you and if you would specify it anyway, it will be overridden.
-
+Maybe you noticed that [entry](https://webpack.github.io/docs/configuration.html#entry) and [output.path](https://webpack.github.io/docs/configuration.html#output-path) are completely missing in this config.
+mocha-webpack does this automatically for you, but it respects custom `output` settings. This is especially useful, when you want to write the files to disk with an additional plugin.
 
 
 ## Sourcemaps

--- a/package.json
+++ b/package.json
@@ -86,7 +86,10 @@
     "nyc": "^11.3.0",
     "sass-loader": "~6.0.0",
     "sinon": "^4.0.1",
-    "webpack": "^4"
+    "tiny-worker": "^2.1.2",
+    "webpack": "^4",
+    "worker-loader": "^1.1.1",
+    "write-file-webpack-plugin": "^4.2.0"
   },
   "dependencies": {
     "babel-runtime": "^6.18.0",

--- a/test/integration/cli/custom-output-path.test.js
+++ b/test/integration/cli/custom-output-path.test.js
@@ -1,6 +1,5 @@
 /* eslint-env node, mocha */
 /* eslint-disable func-names, prefer-arrow-callback, max-len */
-
 import { assert } from 'chai';
 import path from 'path';
 import fs from 'fs';
@@ -12,28 +11,26 @@ const fixtureDir = path.relative(process.cwd(), path.join(__dirname, 'fixture'))
 const binPath = path.relative(process.cwd(), path.join('bin', '_mocha'));
 
 describe('custom output path', function () {
-  context('uses custom outpath path', function () {
-    before(function () {
-      this.passingTest = normalizePath(path.join(fixtureDir, 'custom-output-path/test/test.js'));
-      this.webpackConfigPath = normalizePath(path.join(fixtureDir, 'custom-output-path/webpack.config-test.js'));
-      this.webpackConfig = require('./fixture/custom-output-path/webpack.config-test.js'); // eslint-disable-line global-require
-    });
+  before(function () {
+    this.passingTest = normalizePath(path.join(fixtureDir, 'custom-output-path/test/test.js'));
+    this.webpackConfigPath = normalizePath(path.join(fixtureDir, 'custom-output-path/webpack.config-test.js'));
+    this.webpackConfig = require('./fixture/custom-output-path/webpack.config-test.js'); // eslint-disable-line global-require
+  });
 
-    beforeEach(function () {
-      return del(this.webpackConfig.output.path);
-    });
+  beforeEach(function () {
+    return del(this.webpackConfig.output.path);
+  });
 
-    it('runs successful test', function (done) {
-      exec(`node ${binPath}  --webpack-config "${this.webpackConfigPath}" "${this.passingTest}"`, (err, output) => {
-        assert.isNull(err);
-        assert.include(output, '1 passing');
-        assert.isTrue(fs.existsSync(path.join(this.webpackConfig.output.path, this.webpackConfig.output.filename)));
-        done();
-      });
+  it('runs test successfully', function (done) {
+    exec(`node ${binPath}  --webpack-config "${this.webpackConfigPath}" "${this.passingTest}"`, (err, output) => {
+      assert.isNull(err);
+      assert.include(output, '1 passing');
+      assert.isTrue(fs.existsSync(path.join(this.webpackConfig.output.path, this.webpackConfig.output.filename)));
+      done();
     });
+  });
 
-    afterEach(function () {
-      return del(this.webpackConfig.output.path);
-    });
+  afterEach(function () {
+    return del(this.webpackConfig.output.path);
   });
 });

--- a/test/integration/cli/custom-output-path.test.js
+++ b/test/integration/cli/custom-output-path.test.js
@@ -1,0 +1,39 @@
+/* eslint-env node, mocha */
+/* eslint-disable func-names, prefer-arrow-callback, max-len */
+
+import { assert } from 'chai';
+import path from 'path';
+import fs from 'fs';
+import del from 'del';
+import normalizePath from 'normalize-path';
+import { exec } from './util/childProcess';
+
+const fixtureDir = path.relative(process.cwd(), path.join(__dirname, 'fixture'));
+const binPath = path.relative(process.cwd(), path.join('bin', '_mocha'));
+
+describe('custom output path', function () {
+  context('uses custom outpath path', function () {
+    before(function () {
+      this.passingTest = normalizePath(path.join(fixtureDir, 'custom-output-path/test/test.js'));
+      this.webpackConfigPath = normalizePath(path.join(fixtureDir, 'custom-output-path/webpack.config-test.js'));
+      this.webpackConfig = require('./fixture/custom-output-path/webpack.config-test.js'); // eslint-disable-line global-require
+    });
+
+    beforeEach(function () {
+      return del(this.webpackConfig.output.path);
+    });
+
+    it('runs successful test', function (done) {
+      exec(`node ${binPath}  --webpack-config "${this.webpackConfigPath}" "${this.passingTest}"`, (err, output) => {
+        assert.isNull(err);
+        assert.include(output, '1 passing');
+        assert.isTrue(fs.existsSync(path.join(this.webpackConfig.output.path, this.webpackConfig.output.filename)));
+        done();
+      });
+    });
+
+    afterEach(function () {
+      return del(this.webpackConfig.output.path);
+    });
+  });
+});

--- a/test/integration/cli/fixture/custom-output-path/test/test.js
+++ b/test/integration/cli/fixture/custom-output-path/test/test.js
@@ -1,0 +1,5 @@
+describe('test', function () {
+
+  it('it works', function () {});
+
+});

--- a/test/integration/cli/fixture/custom-output-path/webpack.config-test.js
+++ b/test/integration/cli/fixture/custom-output-path/webpack.config-test.js
@@ -1,0 +1,16 @@
+/* eslint-disable */
+const path = require('path');
+const WriteFilePlugin = require('write-file-webpack-plugin');
+
+module.exports = {
+  mode: 'development',
+  target: 'node',
+  output: {
+    filename: 'bundle-custom-output-path.js',
+    path: path.join(__dirname,  '../../fixtureTmp'),
+    publicPath: ''
+  },
+  plugins: [
+    new WriteFilePlugin(),
+  ],
+};

--- a/test/integration/cli/fixture/webworker/src/worker.js
+++ b/test/integration/cli/fixture/webworker/src/worker.js
@@ -1,0 +1,5 @@
+/* eslint-disable */
+
+self.addEventListener("message", (event) => {
+  self.postMessage(event.data[0] + event.data[1]);
+});

--- a/test/integration/cli/fixture/webworker/test/worker.js
+++ b/test/integration/cli/fixture/webworker/test/worker.js
@@ -1,0 +1,27 @@
+const assert = require('assert');
+const MyWorker = require('worker-loader!../src/worker');
+
+describe('worker', function () {
+
+  beforeEach(function () {
+    this.worker = new MyWorker();
+  });
+
+  it('adds', function () {
+    return Promise
+      .resolve()
+      .then(() => {
+        this.worker.postMessage([1, 1]);
+        return new Promise(resolve => {
+          this.worker.onmessage = (result) => {
+            resolve(result.data);
+          };
+        });
+      })
+      .then((result) => assert.equal(result, 2));
+  });
+
+  afterEach(function () {
+    this.worker.terminate();
+  });
+});

--- a/test/integration/cli/fixture/webworker/webpack.config-test.js
+++ b/test/integration/cli/fixture/webworker/webpack.config-test.js
@@ -1,0 +1,13 @@
+/* eslint-disable */
+global.Worker = require('tiny-worker'); // webworker polyfill for node
+const WriteFilePlugin = require('write-file-webpack-plugin');
+
+module.exports = {
+  mode: 'development',
+  target: 'node',
+  plugins: [
+    new WriteFilePlugin({
+      test: /\.worker\.js$/,
+    }),
+  ],
+};

--- a/test/integration/cli/webworker.test.js
+++ b/test/integration/cli/webworker.test.js
@@ -1,6 +1,5 @@
 /* eslint-env node, mocha */
 /* eslint-disable func-names, prefer-arrow-callback */
-
 import { assert } from 'chai';
 import path from 'path';
 import normalizePath from 'normalize-path';
@@ -11,17 +10,15 @@ const fixtureDir = path.relative(process.cwd(), path.join(__dirname, 'fixture'))
 const binPath = path.relative(process.cwd(), path.join('bin', '_mocha'));
 
 describe('webworker', function () {
-  context('runs tests successfull', function () {
-    before(function () {
-      this.passingTest = normalizePath(path.join(fixtureDir, 'webworker/test/worker.js'));
-      this.webpackConfig = normalizePath(path.join(fixtureDir, 'webworker/webpack.config-test.js'));
-    });
-    it('runs successful test', function (done) {
-      exec(`node ${binPath}  --webpack-config "${this.webpackConfig}" "${this.passingTest}"`, (err, output) => {
-        assert.isNull(err);
-        assert.include(output, '1 passing');
-        done();
-      });
+  before(function () {
+    this.passingTest = normalizePath(path.join(fixtureDir, 'webworker/test/worker.js'));
+    this.webpackConfig = normalizePath(path.join(fixtureDir, 'webworker/webpack.config-test.js'));
+  });
+  it('runs test successfully', function (done) {
+    exec(`node ${binPath}  --webpack-config "${this.webpackConfig}" "${this.passingTest}"`, (err, output) => {
+      assert.isNull(err);
+      assert.include(output, '1 passing');
+      done();
     });
   });
 });

--- a/test/integration/cli/webworker.test.js
+++ b/test/integration/cli/webworker.test.js
@@ -1,0 +1,27 @@
+/* eslint-env node, mocha */
+/* eslint-disable func-names, prefer-arrow-callback */
+
+import { assert } from 'chai';
+import path from 'path';
+import normalizePath from 'normalize-path';
+import { exec } from './util/childProcess';
+
+
+const fixtureDir = path.relative(process.cwd(), path.join(__dirname, 'fixture'));
+const binPath = path.relative(process.cwd(), path.join('bin', '_mocha'));
+
+describe('webworker', function () {
+  context('runs tests successfull', function () {
+    before(function () {
+      this.passingTest = normalizePath(path.join(fixtureDir, 'webworker/test/worker.js'));
+      this.webpackConfig = normalizePath(path.join(fixtureDir, 'webworker/webpack.config-test.js'));
+    });
+    it('runs successful test', function (done) {
+      exec(`node ${binPath}  --webpack-config "${this.webpackConfig}" "${this.passingTest}"`, (err, output) => {
+        assert.isNull(err);
+        assert.include(output, '1 passing');
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
This PR gives more control on the output settings. All files are still compiled to and read from memory, but this PR allows to use mocha-webpack with a plugin that writes files to disk at the desired location. 

Use case is #203 and maybe #29.

Breaking changes:
- use users `output.filename` if defined, otherwise use webpack's default
- use users `output.path` if defined, otherwise mocha-webpack provides an path (.tmp as before)
- use users `output.publicPath` if `output.path` is defined, otherwise if users `output.path` is missing, mocha-webpack provides an path