### PR TITLE
optimize deployment

### DIFF
--- a/.bookignore
+++ b/.bookignore
@@ -1,0 +1,8 @@
+# Ignore file for gitbook
+
+# Ignore everything
+*
+# But not these files...
+!*.md
+!book.json
+!docs

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "posttest": "npm run lint",
     "docs:clean": "del-cli _book",
     "docs:prepare": "gitbook install",
-    "docs:build": "npm run docs:prepare && gitbook build",
+    "docs:build": "npm run docs:clean && npm run docs:prepare && gitbook build",
     "docs:watch": "npm run docs:prepare && gitbook serve --port 3000",
-    "docs:deploy": "npm run docs:clean && npm run docs:build && gh-pages -d _book",
-    "prepublish": "npm run build",
+    "docs:deploy": "gh-pages -d _book",
+    "prepublish": "npm run build  && npm run docs:build",
     "postpublish": "npm run docs:deploy",
     "release": "np"
   },


### PR DESCRIPTION
- build docs before npm publish to ensure that this will work
- add bookignore again to deploy a minimum of files

Seems like a published 2.0.0-alpha.0 a few days ago, although the deployment failed. Now all build steps are executed before npm publish. 