### PR TITLE
Pass argv.mode to webpack.config.js function.

### DIFF
--- a/src/cli/requireWebpackConfig.js
+++ b/src/cli/requireWebpackConfig.js
@@ -103,7 +103,8 @@ export default function requireWebpackConfig(webpackConfig, required, env, mode)
   config = config.default || config;
 
   if (typeof config === 'function') {
-    config = config(env);
+    const argv = { mode };
+    config = config(env, argv);
   }
 
   if (mode != null) {

--- a/test/unit/cli/fixture/webpackConfig/webpack.config-function.coffee
+++ b/test/unit/cli/fixture/webpackConfig/webpack.config-function.coffee
@@ -1,5 +1,5 @@
-module.exports = (env) ->
-  if env == 'test'
+module.exports = (env, argv) ->
+  if (env == 'test' && argv.mode == 'development')
     return {
       mode: 'development'
       target: 'node'

--- a/test/unit/cli/requireWebpackConfig.test.js
+++ b/test/unit/cli/requireWebpackConfig.test.js
@@ -38,7 +38,7 @@ describe('requireWebpackConfig', () => {
 
   it('supports config that exports a function', () => {
     const configPath = getConfigPath('.js', 'config-function');
-    assert.deepEqual(requireWebpackConfig(configPath, false, 'test'), expectedConfig);
+    assert.deepEqual(requireWebpackConfig(configPath, false, 'test', 'development'), expectedConfig);
   });
 
   it('throws error when multi compiler config is given', () => {


### PR DESCRIPTION
With Webpack 4 the configuration as a function can receive a second argument `argv`, which for all intents and purposes is just a way of finding out what `--mode` you're in:

https://webpack.js.org/configuration/configuration-types

This PR adds that functionality. I do not expect there would be any compatibility issues as previously the second argument was just undefined.