### PR TITLE
Update JSDOM setup.js example

### DIFF
--- a/docs/guides/jsdom.md
+++ b/docs/guides/jsdom.md
@@ -15,21 +15,27 @@ Then create a helper script to prepare the jsdom environment, e.g. `setup.js`.
 
 **setup.js**
 ```js
-const jsdom = require('jsdom').jsdom;
+import jsdom from "jsdom";
 
-global.document = jsdom('');
-global.window = document.defaultView;
-window.console = global.console;
+const { JSDOM } = jsdom;
+const dom = new JSDOM("");
 
-Object.keys(document.defaultView).forEach((property) => {
-  if (typeof global[property] === 'undefined') {
-    global[property] = document.defaultView[property];
+Object.assign(global, {
+  document: dom.window.document,
+  window: dom.window,
+  navigator: {
+    userAgent: `node.js`
   }
 });
 
-global.navigator = {
-  userAgent: 'node.js'
-};
+window.console = global.console;
+
+Object.getOwnPropertyNames(window)
+  .forEach(property => {
+    if (typeof global[property] === `undefined`) {
+      global[property] = window[property];
+    }
+  });
 ```
 
 As next you need to make sure that the compile `target` in your Webpack configuration is `node`.


### PR DESCRIPTION
Thank you very much for bringing `mocha-webpack` together! 
It's been quite a useful, and definitely helped me speed up development

I was setting up JSDOM, using version 4.5.0 and saw that couple of things had changed since this example was written.

The biggest one being around

```
Object.keys(document.defaultView).forEach
```

The big problem is that a lot of things on the `defaultView` are not enumerable, stuff like `Element`, or `CharacterData`, which means that they were never attached to the `global` object. 
I overcome that problem by using `getOwnPropertyNames`

Hope this makes sense!
Cheers