### PR TITLE
handle chunk sorting failure gracefully

### DIFF
--- a/src/webpack/util/getBuildStats.js
+++ b/src/webpack/util/getBuildStats.js
@@ -15,7 +15,12 @@ export type BuildStats = {
 export default function getBuildStats(stats: Stats, outputPath: string): BuildStats {
   const { chunks, chunkGroups, modules } = stats.compilation;
 
-  const sortedChunks = sortChunks(chunks, chunkGroups);
+  let sortedChunks = chunks;
+  try {
+    sortedChunks = (0, _sortChunks2.default)(chunks, chunkGroups);
+  } catch (e) {
+    // if sort fails (because of circular dependencies for instance), do nothing
+  }
   const affectedModules = getAffectedModuleIds(chunks, modules);
 
   const entries = [];


### PR DESCRIPTION
In our project, we have some circular dependencies (don't ask... :-P). That shouldn't prevent us from testing. 
After upgrading to webpack4 and mocha-webpack 2.0.0-beta.0 we ran into the following error when running our tests:

```
TypeError: Converting circular structure to JSON
    at JSON.stringify (<anonymous>)
    at visit (/Users/gseguin/src/web-client/node_modules/toposort/index.js:29:50)
    at visit (/Users/gseguin/src/web-client/node_modules/toposort/index.js:47:9)
    at visit (/Users/gseguin/src/web-client/node_modules/toposort/index.js:47:9)
    at Function.toposort [as array] (/Users/gseguin/src/web-client/node_modules/toposort/index.js:22:22)
    at sortChunks (/Users/gseguin/src/web-client/node_modules/mocha-webpack/lib/webpack/util/sortChunks.js:35:41)
    at getBuildStats (/Users/gseguin/src/web-client/node_modules/mocha-webpack/lib/webpack/util/getBuildStats.js:31:49)
    at TestRunner.prepareMocha (/Users/gseguin/src/web-client/node_modules/mocha-webpack/lib/runner/TestRunner.js:135:52)
    at /Users/gseguin/src/web-client/node_modules/mocha-webpack/lib/runner/TestRunner.js:188:38
    at /Users/gseguin/src/web-client/node_modules/mocha-webpack/lib/webpack/compiler/registerReadyCallback.js:26:7
    at AsyncSeriesHook.eval [as callAsync] (eval at create (/Users/gseguin/src/web-client/node_modules/webpack/node_modules/tapable/lib/HookCodeFactory.js:24:12), <anonymous>:27:1)
    at AsyncSeriesHook.lazyCompileHook [as _callAsync] (/Users/gseguin/src/web-client/node_modules/webpack/node_modules/tapable/lib/Hook.js:35:21)
    at emitRecords.err (/Users/gseguin/src/web-client/node_modules/webpack/lib/Compiler.js:257:22)
    at Compiler.emitRecords (/Users/gseguin/src/web-client/node_modules/webpack/lib/Compiler.js:372:39)
    at emitAssets.err (/Users/gseguin/src/web-client/node_modules/webpack/lib/Compiler.js:251:10)
    at hooks.afterEmit.callAsync.err (/Users/gseguin/src/web-client/node_modules/webpack/lib/Compiler.js:358:14)
    at AsyncSeriesHook.eval [as callAsync] (eval at create (/Users/gseguin/src/web-client/node_modules/webpack/node_modules/tapable/lib/HookCodeFactory.js:24:12), <anonymous>:9:1)
    at AsyncSeriesHook.lazyCompileHook [as _callAsync] (/Users/gseguin/src/web-client/node_modules/webpack/node_modules/tapable/lib/Hook.js:35:21)
    at asyncLib.forEach.err (/Users/gseguin/src/web-client/node_modules/webpack/lib/Compiler.js:355:27)
    at done (/Users/gseguin/src/web-client/node_modules/neo-async/async.js:2854:11)
    at /Users/gseguin/src/web-client/node_modules/neo-async/async.js:2805:7
    at MemoryFileSystem.writeFile (/Users/gseguin/src/web-client/node_modules/memory-fs/lib/MemoryFileSystem.js:328:9)
    at writeOut (/Users/gseguin/src/web-client/node_modules/webpack/lib/Compiler.js:339:29)
    at Immediate._onImmediate (/Users/gseguin/src/web-client/node_modules/memory-fs/lib/MemoryFileSystem.js:288:4)
    at runCallback (timers.js:789:20)
    at tryOnImmediate (timers.js:751:5)
    at processImmediate [as _immediateCallback] (timers.js:722:5)
```

Ignoring the exception when sorting the chunks and defaulting `sortedChunks` to `chunks` seems to solve the issue.