### PR TITLE
Updating docs: Add path import

### DIFF
--- a/docs/guides/code-coverage.md
+++ b/docs/guides/code-coverage.md
@@ -88,6 +88,7 @@ Now it's time to setup `istanbul-instrumenter-loader` to get proper code coverag
 ```javascript
 var nodeExternals = require('webpack-node-externals');
 var isCoverage = process.env.NODE_ENV === 'coverage';
+var path = require('path');
 
 module.exports = {
   output: {


### PR DESCRIPTION
Nothing major, was just setting up the environment and noticed a missing import statement in the docs sampe code (section: 'Guides' - 'Code coverage'). Will return 'path not defined' otherwise. This is easy for them to fix by themselves but thought this might make it easier for someone else.